### PR TITLE
Results for NVidia GTX-960 and Raspberry PI 2 (pocl)

### DIFF
--- a/results/NVIDIA_CUDA/GeForce_GTX_960.log
+++ b/results/NVIDIA_CUDA/GeForce_GTX_960.log
@@ -1,0 +1,45 @@
+
+Platform: NVIDIA CUDA
+  Device: GeForce GTX 960
+    Driver version  : 355.11 (Linux x64)
+    Compute units   : 8
+    Clock frequency : 1329 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 82.67
+      float2  : 85.63
+      float4  : 87.22
+      float8  : 81.16
+      float16 : 83.39
+
+    Single-precision compute (GFLOPS)
+      float   : 2550.71
+      float2  : 2747.97
+      float4  : 2793.35
+      float8  : 2728.88
+      float16 : 2760.22
+
+    Double-precision compute (GFLOPS)
+      double   : 89.67
+      double2  : 89.63
+      double4  : 89.46
+      double8  : 89.10
+      double16 : 88.42
+
+    Integer compute (GIOPS)
+      int   : 761.99
+      int2  : 803.24
+      int4  : 816.24
+      int8  : 815.58
+      int16 : 826.16
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer         : 6.58
+      enqueueReadBuffer          : 6.56
+      enqueueMapBuffer(for read) : 6.27
+        memcpy from mapped ptr   : 7.07
+      enqueueUnmap(after write)  : 6.76
+        memcpy to mapped ptr     : 7.12
+
+    Kernel launch latency : 5.16 us
+

--- a/results/Portable_Computing_Language/RaspberryPI2.log
+++ b/results/Portable_Computing_Language/RaspberryPI2.log
@@ -1,0 +1,31 @@
+
+Platform: Portable Computing Language
+  Device: pthread
+    Driver version  : 0.12-pre (Linux ARM)
+    Compute units   : 4
+    Clock frequency : 900 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 0.85
+      float2  : 0.87
+      float4  : 0.76
+      float8  : 0.75
+      float16 : 0.81
+
+    Single-precision compute (GFLOPS)
+      float   : 0.03
+      float2  : 0.03
+      float4  : 0.03
+      float8  : 0.03
+      float16 : 0.03
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer         : 0.79
+      enqueueReadBuffer          : 0.69
+      enqueueMapBuffer(for read) : 12427.57
+        memcpy from mapped ptr   : 0.69
+      enqueueUnmap(after write)  : 18970.70
+        memcpy to mapped ptr     : 0.70
+
+    Kernel launch latency : 190270.91 us
+


### PR DESCRIPTION
I added the results of executions on a NVidia GTX-960 and on a Raspberry PI 2 by using POCL implementation (v0.12 and LLVM 3.5).