### PR TITLE
Global size now is multiple of local size

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -92,8 +92,8 @@ device_info_t getDeviceInfo(cl::Device &d);
 // Return time in us for the given event
 float timeInUS(cl::Event &timeEvent);
 
-// Round to nearest power of 2, or set a maximum power of 2 limit
-uint roundToPowOf2(uint number, int maxPower=-1);
+// Round down to next multiple of the given base with an optional maximum value
+uint roundToMultipleOf(uint number, const uint base, int maxValue = -1);
 
 void populate(float *ptr, uint N);
 void populate(double *ptr, uint N);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -107,16 +107,10 @@ void populate(double *ptr, uint N)
 }
 
 
-uint roundToPowOf2(uint number, int maxPower)
+uint roundToMultipleOf(uint number, const uint base, int maxValue)
 {
-  int i;
+  if(maxValue > 0 && number > static_cast<uint>(maxValue))
+    return (maxValue / base) * base;
 
-  if ((maxPower > 0) && (number > ((uint)1 << maxPower)))
-    return (1 << maxPower);
-
-  for (i=1 ; i < (int)(8*sizeof(int)) ; i++)
-    if (((uint)1 << i) > number)
-      break;
-
-  return (1 << (i-1));
+  return (number / base) * base;
 }

--- a/src/compute_dp.cpp
+++ b/src/compute_dp.cpp
@@ -28,7 +28,7 @@ int clPeak::runComputeDP(cl::CommandQueue &queue, cl::Program &prog, device_info
 
     uint globalWIs = (devInfo.numCUs) * (devInfo.computeWgsPerCU) * (devInfo.maxWGSize);
     uint t = MIN((globalWIs * sizeof(cl_double)), devInfo.maxAllocSize);
-    t = roundToPowOf2(t);
+    t = roundToMultipleOf(t, devInfo.maxWGSize);
     globalWIs = t / sizeof(cl_double);
     cl::Buffer outputBuf = cl::Buffer(ctx, CL_MEM_WRITE_ONLY, (globalWIs * sizeof(cl_double)));
 

--- a/src/compute_hp.cpp
+++ b/src/compute_hp.cpp
@@ -28,7 +28,7 @@ int clPeak::runComputeHP(cl::CommandQueue &queue, cl::Program &prog, device_info
 
     uint globalWIs = (devInfo.numCUs) * (devInfo.computeWgsPerCU) * (devInfo.maxWGSize);
     uint t = MIN((globalWIs * sizeof(cl_half)), devInfo.maxAllocSize);
-    t = roundToPowOf2(t);
+    t = roundToMultipleOf(t, devInfo.maxWGSize);
     globalWIs = t / sizeof(cl_half);
     cl::Buffer outputBuf = cl::Buffer(ctx, CL_MEM_WRITE_ONLY, (globalWIs * sizeof(cl_half)));
 

--- a/src/compute_integer.cpp
+++ b/src/compute_integer.cpp
@@ -22,7 +22,7 @@ int clPeak::runComputeInteger(cl::CommandQueue &queue, cl::Program &prog, device
 
     uint globalWIs = (devInfo.numCUs) * (devInfo.computeWgsPerCU) * (devInfo.maxWGSize);
     uint t = MIN((globalWIs * sizeof(cl_int)), devInfo.maxAllocSize);
-    t = roundToPowOf2(t);
+    t = roundToMultipleOf(t, devInfo.maxWGSize);
     globalWIs = t / sizeof(cl_int);
 
     cl::Buffer outputBuf = cl::Buffer(ctx, CL_MEM_WRITE_ONLY, (globalWIs * sizeof(cl_int)));

--- a/src/compute_sp.cpp
+++ b/src/compute_sp.cpp
@@ -22,7 +22,7 @@ int clPeak::runComputeSP(cl::CommandQueue &queue, cl::Program &prog, device_info
 
     uint globalWIs = (devInfo.numCUs) * (devInfo.computeWgsPerCU) * (devInfo.maxWGSize);
     uint t = MIN((globalWIs * sizeof(cl_float)), devInfo.maxAllocSize);
-    t = roundToPowOf2(t);
+    t = roundToMultipleOf(t, devInfo.maxWGSize);
     globalWIs = t / sizeof(cl_float);
 
     cl::Buffer outputBuf = cl::Buffer(ctx, CL_MEM_WRITE_ONLY, (globalWIs * sizeof(cl_float)));

--- a/src/global_bandwidth.cpp
+++ b/src/global_bandwidth.cpp
@@ -20,9 +20,9 @@ int clPeak::runGlobalBandwidthTest(cl::CommandQueue &queue, cl::Program &prog, d
 
   // Set an upper-limit for cpu devies
   if(devInfo.deviceType & CL_DEVICE_TYPE_CPU) {
-    numItems = roundToPowOf2(maxItems, 25);
+    numItems = roundToMultipleOf(maxItems, devInfo.maxWGSize, 1 << 25);
   } else {
-    numItems = roundToPowOf2(maxItems);
+    numItems = roundToMultipleOf(maxItems, devInfo.maxWGSize);
   }
 
   try

--- a/src/transfer_bandwidth.cpp
+++ b/src/transfer_bandwidth.cpp
@@ -18,9 +18,9 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
 
   // Set an upper-limit for cpu devies
   if(devInfo.deviceType & CL_DEVICE_TYPE_CPU) {
-    numItems = roundToPowOf2(maxItems, 26);
+    numItems = roundToMultipleOf(maxItems, devInfo.maxWGSize, 1 << 26);
   } else {
-    numItems = roundToPowOf2(maxItems);
+    numItems = roundToMultipleOf(maxItems, devInfo.maxWGSize);
   }
 
   try


### PR DESCRIPTION
This fixes #41 by rounding the global work-size down to a multiple of the local work-size.

Possible drawback: The value is now guaranteed to be a multiple of the local work-size, not a power of it!
As far as I can tell, this should have no negative consequences.