### PR TITLE
Use FindOpenCL rather than custom OpenCL finders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 project(clpeak)
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -7,108 +7,52 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-# Determine machine bitness
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(BITNESS 64)
-else()
-  set(BITNESS 32)
+# FindOpenCL.cmake doesn't use OPENCL_ROOT so force it to copy OPENCL_ROOT to
+# AMDAPPSDKROOT which it does use
+if(OPENCL_ROOT)
+  set(ENV{AMDAPPSDKROOT} ${OPENCL_ROOT})
 endif()
 
-# Find OpenCL include directories
-find_path( OPENCL_INCLUDES
-  NAMES CL/cl.h OpenCL/cl.h
-  HINTS
-    $ENV{AMDAPPSDKROOT}/include
-    $ENV{INTELOCLSDKROOT}/include
-    $ENV{CUDA_PATH}/include
-    $ENV{OPENCL_ROOT}/include
-  PATHS
-    /usr/include
-    /usr/local/include
-  )
+find_package(OpenCL)
 
-# Find OpenCL libraries
-if(BITNESS EQUAL 64)
-  find_library( OPENCL_LIBS
-    NAMES OpenCL
-    HINTS
-      $ENV{AMDAPPSDKROOT}/lib
-      $ENV{INTELOCLSDKROOT}/lib
-      $ENV{CUDA_PATH}/lib
-      $ENV{OPENCL_ROOT}/lib
-    PATH_SUFFIXES x86_64 x64
-    PATHS
-      /usr/lib64
-      /usr/lib
-      /usr/local/lib
-  )
-elseif(BITNESS EQUAL 32)
-  find_library( OPENCL_LIBS
-    NAMES OpenCL
-    HINTS
-      $ENV{AMDAPPSDKROOT}/lib
-      $ENV{INTELOCLSDKROOT}/lib
-      $ENV{CUDA_PATH}/lib
-      $ENV{OPENCL_ROOT}/lib
-    PATH_SUFFIXES x86 Win32
-    PATHS
-      /usr/lib32
-      /usr/lib
-      /usr/local/lib
-  )
-endif()
-
-if( (NOT OPENCL_INCLUDES) OR (NOT OPENCL_LIBS) )
+if(NOT OpenCL_FOUND)
   message( FATAL_ERROR "Could not find OpenCL include/libs. Set OPENCL_ROOT to your OpenCL SDK. Download AMD APP SDK "
       "http://developer.amd.com/tools-and-sdks/heterogeneous-computing/amd-accelerated-parallel-processing-app-sdk/ for x86/x64 "
       "or pocl http://pocl.sourceforge.net/ for ARM systems" )
 else()
-  message(STATUS "Selected OpenCL includes from ${OPENCL_INCLUDES}")
-  message(STATUS "Selected OpenCL lib ${OPENCL_LIBS}")
+  message(STATUS "Selected OpenCL includes from ${OpenCL_INCLUDE_DIRS}")
+  message(STATUS "Selected OpenCL lib ${OpenCL_LIBRARIES}")
 endif()
 
-if(CMAKE_CXX_COMPILER MATCHES ".*clang")
-  set(CMAKE_COMPILER_IS_CLANGXX 1)
-endif()
-
-if(APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX  OR CMAKE_COMPILER_IS_CLANGXX)
-  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-  if(GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7 OR CMAKE_COMPILER_IS_CLANGXX)
-    add_definitions("-std=gnu++11")
-  elseif(GCC_VERSION VERSION_GREATER 4.3 OR GCC_VERSION VERSION_EQUAL 4.3)
-    add_definitions("-std=gnu++0x")
-  else()
-    message(FATAL_ERROR "C++11 needed. Therefore a gcc compiler with a version higher than 4.3 is needed.")
-  endif()
-
-  add_definitions("-fPIC -Wall -Wextra -Wno-deprecated-declarations -Wno-unused-parameter -Wno-ignored-attributes")
-endif()
-
-# override cl.hp from deps. Its buggy or not present in come systems
-include_directories("deps/OpenCL-CLHPP/include/")
-
-include_directories(${OPENCL_INCLUDES} "include" "src/kernels")
+set(CMAKE_CXX_STANDARD "11")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(SOURCE_FILES
-  src/common.cpp
-  src/clpeak.cpp
-  src/options.cpp
-  src/logger.cpp
-  src/global_bandwidth.cpp
-  src/compute_sp.cpp
-  src/compute_hp.cpp
-  src/compute_dp.cpp
-  src/compute_integer.cpp
-  src/transfer_bandwidth.cpp
-  src/kernel_latency.cpp
-  src/entry.cpp
-  )
+    src/common.cpp
+    src/clpeak.cpp
+    src/options.cpp
+    src/logger.cpp
+    src/global_bandwidth.cpp
+    src/compute_sp.cpp
+    src/compute_hp.cpp
+    src/compute_dp.cpp
+    src/compute_integer.cpp
+    src/transfer_bandwidth.cpp
+    src/kernel_latency.cpp
+    src/entry.cpp
+)
 
 add_executable(clpeak ${SOURCE_FILES})
 
-target_link_libraries(clpeak ${OPENCL_LIBS})
+target_link_libraries(clpeak ${OpenCL_LIBRARIES})
 
+# override cl.hp from deps. Its buggy or not present in some systems
+target_include_directories(clpeak PRIVATE "deps/OpenCL-CLHPP/include/")
+target_include_directories(clpeak PRIVATE ${OpenCL_INCLUDE_DIRS} "include" "src/kernels")
+
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+   CMAKE_CXX_COMPILER_ID STREQUAL "GNU"   OR
+   CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  target_compile_options(clpeak PRIVATE -fPIC -Wall -Wextra -Wno-deprecated-declarations -Wno-unused-parameter -Wno-ignored-attributes)
+endif()


### PR DESCRIPTION
This change messes with the CMake file to use the built-in FindOpenCL.cmake. This should mean that as more OpenCL SDKs are integrated into the upstream CMake file clpeak will be able to detect them.

I understand that you might not want to mess with something that currently works but doing this helped me to bring up clpeak with a different OpenCL implementation.