### PR TITLE
Move to cl2.hpp as it fixes outputting strings to text files

### DIFF
--- a/include/clpeak.h
+++ b/include/clpeak.h
@@ -1,14 +1,10 @@
 #ifndef CLPEAK_HPP
 #define CLPEAK_HPP
 
-#define __CL_ENABLE_EXCEPTIONS
-
-#include <CL/cl.hpp>
-
 #include <iostream>
 #include <stdio.h>
 #include <iomanip>
-#include <string.h>
+#include <string>
 #include <sstream>
 #include <common.h>
 #include <logger.h>

--- a/include/common.h
+++ b/include/common.h
@@ -1,7 +1,11 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include <CL/cl.hpp>
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#include <CL/cl2.hpp>
+
 #if defined(__APPLE__) || defined(__MACOSX) || defined(__FreeBSD__)
 #include <sys/types.h>
 #endif
@@ -99,4 +103,3 @@ void populate(float *ptr, uint N);
 void populate(double *ptr, uint N);
 
 #endif  // COMMON_H
-

--- a/src/clpeak.cpp
+++ b/src/clpeak.cpp
@@ -2,7 +2,7 @@
 
 #define MSTRINGIFY(...) #__VA_ARGS__
 
-static const char *stringifiedKernels =
+static const std::string stringifiedKernels =
     #include "global_bandwidth_kernels.cl"
     #include "compute_sp_kernels.cl"
     #include "compute_hp_kernels.cl"
@@ -10,7 +10,7 @@ static const char *stringifiedKernels =
     #include "compute_integer_kernels.cl"
     ;
 
-static const char *stringifiedKernelsNoInt =
+static const std::string stringifiedKernelsNoInt =
     #include "global_bandwidth_kernels.cl"
     #include "compute_sp_kernels.cl"
     #include "compute_hp_kernels.cl"
@@ -83,13 +83,13 @@ int clPeak::runAll()
       // Causes Segmentation fault: 11
       if(isIntel || isApple)
       {
-        cl::Program::Sources source(1, make_pair(stringifiedKernelsNoInt, (strlen(stringifiedKernelsNoInt)+1)));
+        cl::Program::Sources source(1, stringifiedKernelsNoInt);
         isComputeInt = false;
         prog = cl::Program(ctx, source);
       }
       else
       {
-        cl::Program::Sources source(1, make_pair(stringifiedKernels, (strlen(stringifiedKernels)+1)));
+        cl::Program::Sources source(1, stringifiedKernels);
         prog = cl::Program(ctx, source);
       }
 
@@ -190,5 +190,3 @@ float clPeak::run_kernel(cl::CommandQueue &queue, cl::Kernel &kernel, cl::NDRang
 
   return (timed / iters);
 }
-
-


### PR DESCRIPTION
This fixes #39. Moving from cl.hpp to cl2.hpp.

I have set the CL_HPP_MINIMUM_OPENCL_VERSION and  CL_HPP_TARGET_OPENCL_VERSION to 120. I am not sure these are the best values for all platforms but they are good for macOS.