### PR TITLE
[src] use CL_PROFILING_COMMAND_END as latency time

### DIFF
--- a/src/kernel_latency.cpp
+++ b/src/kernel_latency.cpp
@@ -38,7 +38,7 @@ int clPeak::runKernelLatency(cl::CommandQueue &queue, cl::Program &prog, device_
       queue.enqueueNDRangeKernel(kernel_v1, cl::NullRange, globalSize, localSize, NULL, &timeEvent);
       queue.finish();
       cl_ulong start = timeEvent.getProfilingInfo<CL_PROFILING_COMMAND_QUEUED>() / 1000;
-      cl_ulong end = timeEvent.getProfilingInfo<CL_PROFILING_COMMAND_START>() / 1000;
+      cl_ulong end = timeEvent.getProfilingInfo<CL_PROFILING_COMMAND_END>() / 1000;
       latency += (float)((int)end - (int)start);
     }
     latency /= static_cast<float>(iters);

--- a/src/kernel_latency.cpp
+++ b/src/kernel_latency.cpp
@@ -8,9 +8,9 @@ int clPeak::runKernelLatency(cl::CommandQueue &queue, cl::Program &prog, device_
     return 0;
 
   cl::Context ctx = queue.getInfo<CL_QUEUE_CONTEXT>();
-  cl_uint numItems = (devInfo.maxWGSize) * (devInfo.numCUs) * FETCH_PER_WI;
-  cl::NDRange globalSize = (numItems / FETCH_PER_WI);
-  cl::NDRange localSize = devInfo.maxWGSize;
+  cl_uint numItems = FETCH_PER_WI;
+  cl::NDRange globalSize = 1;
+  cl::NDRange localSize = 1;
   uint iters = devInfo.kernelLatencyIters;
   float latency;
 


### PR DESCRIPTION
CL_PROFILING_COMMAND_END - CL_PROFILING_COMMAND_QUEUED is real kernel latency