### PR TITLE
Add non-blocking read/write transfers

### DIFF
--- a/src/transfer_bandwidth.cpp
+++ b/src/transfer_bandwidth.cpp
@@ -27,7 +27,7 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
 
     ///////////////////////////////////////////////////////////////////////////
     // enqueueWriteBuffer
-    log->print(TAB TAB TAB "enqueueWriteBuffer         : ");
+    log->print(TAB TAB TAB "enqueueWriteBuffer              : ");
 
     // Dummy warm-up
     queue.enqueueWriteBuffer(clBuffer, CL_TRUE, 0, (numItems * sizeof(float)), arr);
@@ -65,7 +65,7 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
     log->xmlRecord("enqueuewritebuffer", gbps);
     ///////////////////////////////////////////////////////////////////////////
     // enqueueReadBuffer
-    log->print(TAB TAB TAB "enqueueReadBuffer          : ");
+    log->print(TAB TAB TAB "enqueueReadBuffer               : ");
 
     // Dummy warm-up
     queue.enqueueReadBuffer(clBuffer, CL_TRUE, 0, (numItems * sizeof(float)), arr);
@@ -101,8 +101,83 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
     log->print(NEWLINE);
     log->xmlRecord("enqueuereadbuffer", gbps);
     ///////////////////////////////////////////////////////////////////////////
+    // enqueueWriteBuffer non-blocking
+    log->print(TAB TAB TAB "enqueueWriteBuffer non-blocking : ");
+
+    // Dummy warm-up
+    queue.enqueueWriteBuffer(clBuffer, CL_FALSE, 0, (numItems * sizeof(float)), arr);
+    queue.finish();
+
+    timed = 0;
+
+    if (useEventTimer)
+    {
+      for (uint i = 0; i < iters; i++)
+      {
+        cl::Event timeEvent;
+        queue.enqueueWriteBuffer(clBuffer, CL_FALSE, 0, (numItems * sizeof(float)), arr, NULL, &timeEvent);
+        queue.finish();
+        timed += timeInUS(timeEvent);
+      }
+    }
+    else
+    {
+      Timer timer;
+
+      timer.start();
+      for (uint i = 0; i < iters; i++)
+      {
+        queue.enqueueWriteBuffer(clBuffer, CL_FALSE, 0, (numItems * sizeof(float)), arr);
+      }
+      queue.finish();
+      timed = timer.stopAndTime();
+    }
+    timed /= static_cast<float>(iters);
+
+    gbps = ((float)numItems * sizeof(float)) / timed / 1e3f;
+    log->print(gbps);
+    log->print(NEWLINE);
+    log->xmlRecord("enqueuewritebuffer_nonblocking", gbps);
+    ///////////////////////////////////////////////////////////////////////////
+    // enqueueReadBuffer non-blocking
+    log->print(TAB TAB TAB "enqueueReadBuffer non-blocking  : ");
+
+    // Dummy warm-up
+    queue.enqueueReadBuffer(clBuffer, CL_FALSE, 0, (numItems * sizeof(float)), arr);
+    queue.finish();
+
+    timed = 0;
+    if (useEventTimer)
+    {
+      for (uint i = 0; i < iters; i++)
+      {
+        cl::Event timeEvent;
+        queue.enqueueReadBuffer(clBuffer, CL_FALSE, 0, (numItems * sizeof(float)), arr, NULL, &timeEvent);
+        queue.finish();
+        timed += timeInUS(timeEvent);
+      }
+    }
+    else
+    {
+      Timer timer;
+
+      timer.start();
+      for (uint i = 0; i < iters; i++)
+      {
+        queue.enqueueReadBuffer(clBuffer, CL_FALSE, 0, (numItems * sizeof(float)), arr);
+      }
+      queue.finish();
+      timed = timer.stopAndTime();
+    }
+    timed /= static_cast<float>(iters);
+
+    gbps = ((float)numItems * sizeof(float)) / timed / 1e3f;
+    log->print(gbps);
+    log->print(NEWLINE);
+    log->xmlRecord("enqueuereadbuffer_nonblocking", gbps);
+    ///////////////////////////////////////////////////////////////////////////
     // enqueueMapBuffer
-    log->print(TAB TAB TAB "enqueueMapBuffer(for read) : ");
+    log->print(TAB TAB TAB "enqueueMapBuffer(for read)      : ");
 
     queue.finish();
 
@@ -146,7 +221,7 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
     ///////////////////////////////////////////////////////////////////////////
 
     // memcpy from mapped ptr
-    log->print(TAB TAB TAB TAB "memcpy from mapped ptr   : ");
+    log->print(TAB TAB TAB TAB "memcpy from mapped ptr        : ");
     queue.finish();
 
     timed = 0;
@@ -175,7 +250,7 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
     ///////////////////////////////////////////////////////////////////////////
 
     // enqueueUnmap
-    log->print(TAB TAB TAB "enqueueUnmap(after write)  : ");
+    log->print(TAB TAB TAB "enqueueUnmap(after write)       : ");
 
     queue.finish();
 
@@ -219,7 +294,7 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
     ///////////////////////////////////////////////////////////////////////////
 
     // memcpy to mapped ptr
-    log->print(TAB TAB TAB TAB "memcpy to mapped ptr     : ");
+    log->print(TAB TAB TAB TAB "memcpy to mapped ptr          : ");
     queue.finish();
 
     timed = 0;


### PR DESCRIPTION
Transfer bandwidth test includes enqueueWriteBuffer and enqueueReadBuffer scenarios, both of these use blocking versions of OpenCL calls. On Intel it seems that some drivers might use CPU instead of GPU to perform the blocking transfer.

The possible solution is to add non-blocking versions of enqueueWriteBuffer and enqueueReadBuffer to the transfer bandwidth test.

As a verification, an output from running on idle machine: 
```
clpeak.exe --transfer-bandwidth -d 1

Platform: Intel(R) OpenCL
  Device: Intel(R) HD Graphics 520
    Driver version  : 26.20.100.7212 (Win64)
    Compute units   : 24
    Clock frequency : 1000 MHz

    Transfer bandwidth (GBPS)
      enqueueWriteBuffer              : 4.65
      enqueueReadBuffer               : 4.62
      enqueueWriteBuffer non-blocking : 4.85
      enqueueReadBuffer non-blocking  : 4.78
      enqueueMapBuffer(for read)      : 252677.97
        memcpy from mapped ptr        : 4.63
      enqueueUnmap(after write)       : 338588.47
        memcpy to mapped ptr          : 4.18
```

and an output from running while an external app was fully utilizing the CPU:
```
clpeak.exe --transfer-bandwidth -d 1

Platform: Intel(R) OpenCL
  Device: Intel(R) HD Graphics 520
    Driver version  : 26.20.100.7212 (Win64)
    Compute units   : 24
    Clock frequency : 1000 MHz

    Transfer bandwidth (GBPS)
      enqueueWriteBuffer              : 3.03
      enqueueReadBuffer               : 3.10
      enqueueWriteBuffer non-blocking : 4.80
      enqueueReadBuffer non-blocking  : 4.74
      enqueueMapBuffer(for read)      : 302311.13
        memcpy from mapped ptr        : 3.13
      enqueueUnmap(after write)       : 513012.84
        memcpy to mapped ptr          : 3.33
```

As you can see, non-blocking transfers perform exactly the same in both runs.