### PR TITLE
Added 24bit fast MAD Integer Compute test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(CLPEAK_SOURCE_FILES
     src/compute_hp.cpp
     src/compute_dp.cpp
     src/compute_integer.cpp
+	src/compute_integer_fast.cpp
     src/transfer_bandwidth.cpp
     src/kernel_latency.cpp
     src/entry.cpp

--- a/include/clpeak.h
+++ b/include/clpeak.h
@@ -44,6 +44,8 @@ public:
 
   int runComputeInteger(cl::CommandQueue &queue, cl::Program &prog, device_info_t &devInfo);
 
+  int runComputeIntFast(cl::CommandQueue &queue, cl::Program &prog, device_info_t &devInfo);
+
   int runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog, device_info_t &devInfo);
 
   int runKernelLatency(cl::CommandQueue &queue, cl::Program &prog, device_info_t &devInfo);

--- a/include/clpeak.h
+++ b/include/clpeak.h
@@ -22,7 +22,7 @@ class clPeak
 public:
 
   bool forcePlatform, forceDevice, useEventTimer;
-  bool isGlobalBW, isComputeSP, isComputeDP, isComputeInt, isTransferBW, isKernelLatency;
+  bool isGlobalBW, isComputeSP, isComputeDP, isComputeIntFast, isComputeInt, isTransferBW, isKernelLatency;
   ulong specifiedPlatform, specifiedDevice;
   logger *log;
 

--- a/src/clpeak.cpp
+++ b/src/clpeak.cpp
@@ -8,6 +8,7 @@ static const char *stringifiedKernels =
 #include "compute_sp_kernels.cl"
 #include "compute_hp_kernels.cl"
 #include "compute_dp_kernels.cl"
+#include "compute_int24_kernels.cl"
 #include "compute_integer_kernels.cl"
     ;
 

--- a/src/clpeak.cpp
+++ b/src/clpeak.cpp
@@ -20,7 +20,7 @@ extern "C"
 #endif
 
 clPeak::clPeak() : forcePlatform(false), forceDevice(false), useEventTimer(false),
-                   isGlobalBW(true), isComputeSP(true), isComputeDP(true), isComputeInt(true),
+                   isGlobalBW(true), isComputeSP(true), isComputeDP(true), isComputeIntFast(true), isComputeInt(true),
                    isTransferBW(true), isKernelLatency(true),
                    specifiedPlatform(0), specifiedDevice(0)
 {
@@ -110,6 +110,7 @@ int clPeak::runAll()
         runComputeSP(queue, prog, devInfo);
         runComputeHP(queue, prog, devInfo);
         runComputeDP(queue, prog, devInfo);
+		runComputeIntFast(queue, prog, devInfo);
         runComputeInteger(queue, prog, devInfo);
         runTransferBandwidthTest(queue, prog, devInfo);
         runKernelLatency(queue, prog, devInfo);

--- a/src/compute_integer_fast.cpp
+++ b/src/compute_integer_fast.cpp
@@ -1,0 +1,128 @@
+#include <clpeak.h>
+
+int clPeak::runComputeIntFast(cl::CommandQueue &queue, cl::Program &prog, device_info_t &devInfo)
+{
+  float timed, gflops;
+  cl_uint workPerWI;
+  cl::NDRange globalSize, localSize;
+  cl_int A = 4;
+  uint iters = devInfo.computeIters;
+
+  if (!isComputeIntFast)
+    return 0;
+
+  try
+  {
+    log->print(NEWLINE TAB TAB "Integer compute Fast 24bit (GIOPS)" NEWLINE);
+    log->xmlOpenTag("integer_compute_fast");
+    log->xmlAppendAttribs("unit", "gflops");
+
+    cl::Context ctx = queue.getInfo<CL_QUEUE_CONTEXT>();
+
+    uint64_t globalWIs = (devInfo.numCUs) * (devInfo.computeWgsPerCU) * (devInfo.maxWGSize);
+    uint64_t t = MIN((globalWIs * sizeof(cl_int)), devInfo.maxAllocSize) / sizeof(cl_int);
+    globalWIs = roundToMultipleOf(t, devInfo.maxWGSize);
+
+    cl::Buffer outputBuf = cl::Buffer(ctx, CL_MEM_WRITE_ONLY, (globalWIs * sizeof(cl_int)));
+
+    globalSize = globalWIs;
+    localSize = devInfo.maxWGSize;
+
+    cl::Kernel kernel_v1(prog, "compute_intfast_v1");
+    kernel_v1.setArg(0, outputBuf), kernel_v1.setArg(1, A);
+
+    cl::Kernel kernel_v2(prog, "compute_intfast_v2");
+    kernel_v2.setArg(0, outputBuf), kernel_v2.setArg(1, A);
+
+    cl::Kernel kernel_v4(prog, "compute_intfast_v4");
+    kernel_v4.setArg(0, outputBuf), kernel_v4.setArg(1, A);
+
+    cl::Kernel kernel_v8(prog, "compute_intfast_v8");
+    kernel_v8.setArg(0, outputBuf), kernel_v8.setArg(1, A);
+
+    cl::Kernel kernel_v16(prog, "compute_intfast_v16");
+    kernel_v16.setArg(0, outputBuf), kernel_v16.setArg(1, A);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Vector width 1
+    log->print(TAB TAB TAB "int   : ");
+
+    workPerWI = 2048; // Indicates integer operations executed per work-item
+
+    timed = run_kernel(queue, kernel_v1, globalSize, localSize, iters);
+
+    gflops = (static_cast<float>(globalWIs) * static_cast<float>(workPerWI)) / timed / 1e3f;
+
+    log->print(gflops);
+    log->print(NEWLINE);
+    log->xmlRecord("int", gflops);
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Vector width 2
+    log->print(TAB TAB TAB "int2  : ");
+
+    workPerWI = 2048;
+
+    timed = run_kernel(queue, kernel_v2, globalSize, localSize, iters);
+
+    gflops = (static_cast<float>(globalWIs) * static_cast<float>(workPerWI)) / timed / 1e3f;
+
+    log->print(gflops);
+    log->print(NEWLINE);
+    log->xmlRecord("int2", gflops);
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Vector width 4
+    log->print(TAB TAB TAB "int4  : ");
+
+    workPerWI = 2048;
+
+    timed = run_kernel(queue, kernel_v4, globalSize, localSize, iters);
+
+    gflops = (static_cast<float>(globalWIs) * static_cast<float>(workPerWI)) / timed / 1e3f;
+
+    log->print(gflops);
+    log->print(NEWLINE);
+    log->xmlRecord("int4", gflops);
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Vector width 8
+    log->print(TAB TAB TAB "int8  : ");
+
+    workPerWI = 2048;
+
+    timed = run_kernel(queue, kernel_v8, globalSize, localSize, iters);
+
+    gflops = (static_cast<float>(globalWIs) * static_cast<float>(workPerWI)) / timed / 1e3f;
+
+    log->print(gflops);
+    log->print(NEWLINE);
+    log->xmlRecord("int8", gflops);
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Vector width 16
+    log->print(TAB TAB TAB "int16 : ");
+
+    workPerWI = 2048;
+
+    timed = run_kernel(queue, kernel_v16, globalSize, localSize, iters);
+
+    gflops = (static_cast<float>(globalWIs) * static_cast<float>(workPerWI)) / timed / 1e3f;
+
+    log->print(gflops);
+    log->print(NEWLINE);
+    log->xmlRecord("int16", gflops);
+    ///////////////////////////////////////////////////////////////////////////
+    log->xmlCloseTag(); // integer_compute
+  }
+  catch (cl::Error &error)
+  {
+    stringstream ss;
+    ss << error.what() << " (" << error.err() << ")" NEWLINE
+       << TAB TAB TAB "Tests skipped" NEWLINE;
+    log->print(ss.str());
+    return -1;
+  }
+
+  return 0;
+}

--- a/src/kernels/compute_int24_kernels.cl
+++ b/src/kernels/compute_int24_kernels.cl
@@ -1,0 +1,84 @@
+MSTRINGIFY(
+
+// Avoiding auto-vectorize by using vector-width locked dependent code
+
+\n#undef MAD_4INT
+\n#undef MAD_16INT
+\n#undef MAD_64INT
+\n
+\n#define MAD_4INT(x, y)  x = mad24(y,x,y);   y = mad24(x,y,x);   x = mad24(y,x,y);   y = mad24(x,y,x);
+\n#define MAD_16INT(x, y) MAD_4INT(x, y);     MAD_4INT(x, y);     MAD_4INT(x, y);     MAD_4INT(x, y);
+\n#define MAD_64INT(x, y) MAD_16INT(x, y);    MAD_16INT(x, y);    MAD_16INT(x, y);    MAD_16INT(x, y);
+\n
+
+__kernel void compute_intfast_v1(__global int *ptr, int _A)
+{
+    int x = _A;
+    int y = (int)get_local_id(0);
+
+    for(int i=0; i<64; i++)
+    {
+        MAD_16INT(x, y);
+    }
+
+    ptr[get_global_id(0)] = y;
+}
+
+
+__kernel void compute_intfast_v2(__global int *ptr, int _A)
+{
+    int2 x = (int2)(_A, (_A+1));
+    int2 y = (int2)get_local_id(0);
+
+    for(int i=0; i<32; i++)
+    {
+        MAD_16INT(x, y);
+    }
+
+    ptr[get_global_id(0)] = (y.S0) + (y.S1);
+}
+
+__kernel void compute_intfast_v4(__global int *ptr, int _A)
+{
+    int4 x = (int4)(_A, (_A+1), (_A+2), (_A+3));
+    int4 y = (int4)get_local_id(0);
+
+    for(int i=0; i<16; i++)
+    {
+        MAD_16INT(x, y);
+    }
+
+    ptr[get_global_id(0)] = (y.S0) + (y.S1) + (y.S2) + (y.S3);
+}
+
+
+__kernel void compute_intfast_v8(__global int *ptr, int _A)
+{
+    int8 x = (int8)(_A, (_A+1), (_A+2), (_A+3), (_A+4), (_A+5), (_A+6), (_A+7));
+    int8 y = (int8)get_local_id(0);
+
+    for(int i=0; i<8; i++)
+    {
+        MAD_16INT(x, y);
+    }
+
+    ptr[get_global_id(0)] = (y.S0) + (y.S1) + (y.S2) + (y.S3) + (y.S4) + (y.S5) + (y.S6) + (y.S7);
+}
+
+__kernel void compute_intfast_v16(__global int *ptr, int _A)
+{
+    int16 x = (int16)(_A, (_A+1), (_A+2), (_A+3), (_A+4), (_A+5), (_A+6), (_A+7),
+                    (_A+8), (_A+9), (_A+10), (_A+11), (_A+12), (_A+13), (_A+14), (_A+15));
+    int16 y = (int16)get_local_id(0);
+
+    for(int i=0; i<4; i++)
+    {
+        MAD_16INT(x, y);
+    }
+
+    int2 t = (y.S01) + (y.S23) + (y.S45) + (y.S67) + (y.S89) + (y.SAB) + (y.SCD) + (y.SEF);
+    ptr[get_global_id(0)] = t.S0 + t.S1;
+}
+
+
+)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -14,6 +14,7 @@ static const char *helpStr =
     "\n  --compute-sp                selectively run single precision compute test"
     "\n  --compute-dp                selectively run double precision compute test"
     "\n  --compute-integer           selectively run integer compute test"
+	"\n  --compute-intfast           selectively run integer 24bit compute test"
     "\n  --transfer-bandwidth        selectively run transfer bandwidth test"
     "\n  --kernel-latency            selectively run kernel latency test"
     "\n  --all-tests                 run all above tests [default]"
@@ -68,12 +69,12 @@ int clPeak::parseArgs(int argc, char **argv)
     {
       useEventTimer = true;
     }
-    else if ((strcmp(argv[i], "--global-bandwidth") == 0) || (strcmp(argv[i], "--compute-sp") == 0) || (strcmp(argv[i], "--compute-dp") == 0) || (strcmp(argv[i], "--compute-integer") == 0) || (strcmp(argv[i], "--transfer-bandwidth") == 0) || (strcmp(argv[i], "--kernel-latency") == 0))
+    else if ((strcmp(argv[i], "--global-bandwidth") == 0) || (strcmp(argv[i], "--compute-sp") == 0) || (strcmp(argv[i], "--compute-dp") == 0) || (strcmp(argv[i], "--compute-integer") == 0) || (strcmp(argv[i], "--compute-intfast") == 0) || (strcmp(argv[i], "--transfer-bandwidth") == 0) || (strcmp(argv[i], "--kernel-latency") == 0))
     {
       // Disable all and enable only selected ones
       if (!forcedTests)
       {
-        isGlobalBW = isComputeSP = isComputeDP = isComputeInt = isTransferBW = isKernelLatency = false;
+        isGlobalBW = isComputeSP = isComputeDP = isComputeInt = isComputeIntFast = isTransferBW = isKernelLatency = false;
         forcedTests = true;
       }
 
@@ -93,6 +94,10 @@ int clPeak::parseArgs(int argc, char **argv)
       {
         isComputeInt = true;
       }
+	  else if (strcmp(argv[i], "--compute-intfast") == 0)
+	  {
+	  	isComputeIntFast = true;
+	  }
       else if (strcmp(argv[i], "--transfer-bandwidth") == 0)
       {
         isTransferBW = true;
@@ -104,7 +109,7 @@ int clPeak::parseArgs(int argc, char **argv)
     }
     else if (strcmp(argv[i], "--all-tests") == 0)
     {
-      isGlobalBW = isComputeSP = isComputeDP = isComputeInt = isTransferBW = isKernelLatency = true;
+      isGlobalBW = isComputeSP = isComputeDP = isComputeInt = isComputeIntFast = isTransferBW = isKernelLatency = true;
     }
     else if (strcmp(argv[i], "--enable-xml-dump") == 0)
     {


### PR DESCRIPTION
Relatively simple change to add a 24bit Integer compute test using OpenCL built-in function `mad24`.
Useful for testing Radeon GPU's that support 24bit Integer math on mantissa of FP32 units.

`mul24` is also available but not used in this test.