### PR TITLE
Updated results with various Intel, AMD and NVidia hardware

### DIFF
--- a/results/AMD_Accelerated_Parallel_Processing/Radeon-MI50-PCIeGen3.log
+++ b/results/AMD_Accelerated_Parallel_Processing/Radeon-MI50-PCIeGen3.log
@@ -1,0 +1,61 @@
+
+Platform: AMD Accelerated Parallel Processing
+  Device: gfx906
+    Driver version  : 3204.0 (HSA1.1,LC) (Linux x64)
+    Compute units   : 60
+    Clock frequency : 1725 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 766.24
+      float2  : 756.53
+      float4  : 740.95
+      float8  : 727.71
+      float16 : 685.31
+
+    Single-precision compute (GFLOPS)
+      float   : 12886.15
+      float2  : 12773.94
+      float4  : 12636.76
+      float8  : 12363.97
+      float16 : 12180.00
+
+    Half-precision compute (GFLOPS)
+      half   : 6522.77
+      half2  : 24971.55
+      half4  : 24781.20
+      half8  : 24465.16
+      half16 : 23955.72
+
+    Double-precision compute (GFLOPS)
+      double   : 6350.20
+      double2  : 6319.02
+      double4  : 6291.70
+      double8  : 5880.47
+      double16 : 6143.47
+
+    Integer compute (GIOPS)
+      int   : 4325.27
+      int2  : 4317.88
+      int4  : 4307.68
+      int8  : 4289.82
+      int16 : 4242.46
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 12395.53
+      int2  : 12199.22
+      int4  : 11631.28
+      int8  : 11757.87
+      int16 : 11833.97
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 11.86
+      enqueueReadBuffer               : 11.53
+      enqueueWriteBuffer non-blocking : 11.52
+      enqueueReadBuffer non-blocking  : 11.43
+      enqueueMapBuffer(for read)      : 192599.44
+        memcpy from mapped ptr        : 11.78
+      enqueueUnmap(after write)       : 286331.16
+        memcpy to mapped ptr          : 11.97
+
+    Kernel launch latency : 11.44 us
+

--- a/results/AMD_Accelerated_Parallel_Processing/Radeon-MI50-PCIeGen4-rocm3.10.log
+++ b/results/AMD_Accelerated_Parallel_Processing/Radeon-MI50-PCIeGen4-rocm3.10.log
@@ -1,0 +1,61 @@
+
+Platform: AMD Accelerated Parallel Processing
+  Device: gfx906
+    Driver version  : 3212.0 (HSA1.1,LC) (Linux x64)
+    Compute units   : 60
+    Clock frequency : 1725 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 767.51
+      float2  : 748.01
+      float4  : 675.73
+      float8  : 717.26
+      float16 : 585.05
+
+    Single-precision compute (GFLOPS)
+      float   : 12713.40
+      float2  : 12396.88
+      float4  : 12340.44
+      float8  : 12001.62
+      float16 : 11861.35
+
+    Half-precision compute (GFLOPS)
+      half   : 6434.60
+      half2  : 23781.07
+      half4  : 23540.66
+      half8  : 23181.37
+      half16 : 22714.81
+
+    Double-precision compute (GFLOPS)
+      double   : 6084.21
+      double2  : 6160.23
+      double4  : 5970.83
+      double8  : 5964.05
+      double16 : 5833.33
+
+    Integer compute (GIOPS)
+      int   : 4241.74
+      int2  : 4223.93
+      int4  : 4227.38
+      int8  : 4198.92
+      int16 : 4162.48
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 11717.45
+      int2  : 11599.73
+      int4  : 11107.29
+      int8  : 11331.84
+      int16 : 11263.35
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 15.68
+      enqueueReadBuffer               : 15.39
+      enqueueWriteBuffer non-blocking : 15.61
+      enqueueReadBuffer non-blocking  : 11.47
+      enqueueMapBuffer(for read)      : 85048.86
+        memcpy from mapped ptr        : 15.67
+      enqueueUnmap(after write)       : 182764.56
+        memcpy to mapped ptr          : 16.07
+
+    Kernel launch latency : 10.55 us
+

--- a/results/AMD_Accelerated_Parallel_Processing/Radeon-MI50-PCIeGen4.log
+++ b/results/AMD_Accelerated_Parallel_Processing/Radeon-MI50-PCIeGen4.log
@@ -1,0 +1,61 @@
+
+Platform: AMD Accelerated Parallel Processing
+  Device: gfx906+sram-ecc
+    Driver version  : 3137.0 (HSA1.1,LC) (Linux x64)
+    Compute units   : 60
+    Clock frequency : 1725 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 765.79
+      float2  : 655.94
+      float4  : 645.82
+      float8  : 652.67
+      float16 : 582.26
+
+    Single-precision compute (GFLOPS)
+      float   : 12710.35
+      float2  : 12307.32
+      float4  : 12124.76
+      float8  : 12007.03
+      float16 : 11834.00
+
+    Half-precision compute (GFLOPS)
+      half   : 6422.43
+      half2  : 23564.34
+      half4  : 23395.76
+      half8  : 23167.34
+      half16 : 22676.43
+
+    Double-precision compute (GFLOPS)
+      double   : 5978.52
+      double2  : 5953.91
+      double4  : 5929.22
+      double8  : 5892.56
+      double16 : 5814.56
+
+    Integer compute (GIOPS)
+      int   : 4238.15
+      int2  : 4228.25
+      int4  : 4214.90
+      int8  : 4198.91
+      int16 : 4149.22
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 11816.17
+      int2  : 11582.84
+      int4  : 11094.79
+      int8  : 11323.87
+      int16 : 11321.21
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 15.91
+      enqueueReadBuffer               : 15.35
+      enqueueWriteBuffer non-blocking : 11.95
+      enqueueReadBuffer non-blocking  : 12.24
+      enqueueMapBuffer(for read)      : 130150.53
+        memcpy from mapped ptr        : 15.90
+      enqueueUnmap(after write)       : 248264.02
+        memcpy to mapped ptr          : 16.02
+
+    Kernel launch latency : 15.64 us
+

--- a/results/AMD_Accelerated_Parallel_Processing/Radeon-VII-Pro.log
+++ b/results/AMD_Accelerated_Parallel_Processing/Radeon-VII-Pro.log
@@ -1,0 +1,61 @@
+
+Platform: AMD Accelerated Parallel Processing
+  Device: gfx906
+    Driver version  : 3204.0 (HSA1.1,LC) (Linux x64)
+    Compute units   : 60
+    Clock frequency : 1700 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 783.04
+      float2  : 741.34
+      float4  : 723.88
+      float8  : 732.36
+      float16 : 679.49
+
+    Single-precision compute (GFLOPS)
+      float   : 12727.97
+      float2  : 12632.55
+      float4  : 12403.68
+      float8  : 12147.13
+      float16 : 11960.99
+
+    Half-precision compute (GFLOPS)
+      half   : 6425.83
+      half2  : 24459.28
+      half4  : 24278.00
+      half8  : 23921.18
+      half16 : 23455.81
+
+    Double-precision compute (GFLOPS)
+      double   : 6206.76
+      double2  : 6176.21
+      double4  : 6135.32
+      double8  : 6107.36
+      double16 : 5924.13
+
+    Integer compute (GIOPS)
+      int   : 4186.51
+      int2  : 4019.41
+      int4  : 4003.08
+      int8  : 4029.69
+      int16 : 3976.25
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 11493.50
+      int2  : 10816.38
+      int4  : 10109.61
+      int8  : 10421.03
+      int16 : 10354.31
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 16.91
+      enqueueReadBuffer               : 16.85
+      enqueueWriteBuffer non-blocking : 16.91
+      enqueueReadBuffer non-blocking  : 16.83
+      enqueueMapBuffer(for read)      : 128591.83
+        memcpy from mapped ptr        : 16.77
+      enqueueUnmap(after write)       : 238609.30
+        memcpy to mapped ptr          : 16.91
+
+    Kernel launch latency : 14.06 us
+

--- a/results/Intel(R)_OpenCL/Intel_Core_i7-10875h.log
+++ b/results/Intel(R)_OpenCL/Intel_Core_i7-10875h.log
@@ -1,0 +1,56 @@
+
+Platform: Intel(R) CPU Runtime for OpenCL(TM) Applications
+  Device: Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz
+    Driver version  : 18.1.0.0920 (Linux x64)
+    Compute units   : 16
+    Clock frequency : 2300 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 25.86
+      float2  : 26.54
+      float4  : 24.25
+      float8  : 22.53
+      float16 : 22.85
+
+    Single-precision compute (GFLOPS)
+      float   : 160.53
+      float2  : 319.05
+      float4  : 573.63
+      float8  : 593.37
+      float16 : 320.20
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 160.23
+      double2  : 289.43
+      double4  : 295.46
+      double8  : 171.52
+      double16 : 257.58
+
+    Integer compute (GIOPS)
+      int   : 58.06
+      int2  : 112.07
+      int4  : 206.06
+      int8  : 133.53
+      int16 : 257.37
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 49.43
+      int2  : 89.90
+      int4  : 139.45
+      int8  : 151.41
+      int16 : 88.01
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 10.69
+      enqueueReadBuffer               : 10.74
+      enqueueWriteBuffer non-blocking : 10.68
+      enqueueReadBuffer non-blocking  : 10.57
+      enqueueMapBuffer(for read)      : 13801.31
+        memcpy from mapped ptr        : 10.75
+      enqueueUnmap(after write)       : 16698.94
+        memcpy to mapped ptr          : 10.85
+
+    Kernel launch latency : 3.27 us
+

--- a/results/Intel(R)_OpenCL/Xeon_Phi_5110.log
+++ b/results/Intel(R)_OpenCL/Xeon_Phi_5110.log
@@ -1,0 +1,56 @@
+
+Platform: Intel(R) OpenCL
+  Device: Intel(R) Many Integrated Core Acceleration Card
+    Driver version  : 1.2 (Linux x64)
+    Compute units   : 236
+    Clock frequency : 1052 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 62.52
+      float2  : 44.56
+      float4  : 76.55
+      float8  : 84.92
+      float16 : 2.15
+
+    Single-precision compute (GFLOPS)
+      float   : 1778.74
+      float2  : 1889.33
+      float4  : 1884.25
+      float8  : 1877.49
+      float16 : 1850.36
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 967.75
+      double2  : 966.69
+      double4  : 964.23
+      double8  : 958.01
+      double16 : 295.92
+
+    Integer compute (GIOPS)
+      int   : 968.24
+      int2  : 970.23
+      int4  : 968.07
+      int8  : 968.20
+      int16 : 958.80
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 968.37
+      int2  : 969.56
+      int4  : 967.91
+      int8  : 961.61
+      int16 : 950.62
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 1.86
+      enqueueReadBuffer               : 3.45
+      enqueueWriteBuffer non-blocking : 3.34
+      enqueueReadBuffer non-blocking  : 3.46
+      enqueueMapBuffer(for read)      : 137.16
+        memcpy from mapped ptr        : 3.02
+      enqueueUnmap(after write)       : 6.91
+        memcpy to mapped ptr          : 2.97
+
+    Kernel launch latency : 77.33 us
+

--- a/results/Intel(R)_OpenCL/Xeon_Phi_7120.log
+++ b/results/Intel(R)_OpenCL/Xeon_Phi_7120.log
@@ -1,0 +1,60 @@
+
+Platform: Intel(R) OpenCL
+  Device: Intel(R) Many Integrated Core Acceleration Card
+    Driver version  : 1.2 (Linux x64)
+    Compute units   : 240
+    Clock frequency : 1333 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 68.00
+      float2  : 49.67
+      float4  : 89.31
+      float8  : 101.30
+      float16 : 1.84
+
+    Single-precision compute (GFLOPS)
+      float   : 2130.58
+      float2  : 2262.12
+      float4  : 2255.07
+      float8  : 2247.39
+      float16 : 2213.89
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 1157.62
+      double2  : 1156.44
+      double4  : 1153.55
+      double8  : 1146.15
+      double16 : 354.26
+
+    Integer compute (GIOPS)
+      int   : 1158.72
+      int2  : 1161.01
+      int4  : 1158.69
+      int8  : 1158.58
+      int16 : 1147.02
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 1158.82
+      int2  : 1160.21
+      int4  : 1158.02
+      int8  : 1150.32
+      int16 : 1136.05
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 2.25
+      enqueueReadBuffer               : 5.62
+      enqueueWriteBuffer non-blocking : 4.92
+      enqueueReadBuffer non-blocking  : 5.57
+      enqueueMapBuffer(for read)      : 137.80
+        memcpy from mapped ptr        : 3.71
+      enqueueUnmap(after write)       : 6.55
+        memcpy to mapped ptr          : 3.43
+
+    Kernel launch latency : 79.60 us
+
+
+Platform: NVIDIA CUDA
+
+Platform: AMD Accelerated Parallel Processing

--- a/results/Intel_Graphics_Compute_Runtime/Intel_Core_i7-10875h.log
+++ b/results/Intel_Graphics_Compute_Runtime/Intel_Core_i7-10875h.log
@@ -1,0 +1,61 @@
+
+Platform: Intel(R) OpenCL HD Graphics
+  Device: Intel(R) Graphics Gen9 [0x9bc4]
+    Driver version  : 20.47.18513 (Linux x64)
+    Compute units   : 24
+    Clock frequency : 1200 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 33.18
+      float2  : 33.40
+      float4  : 35.17
+      float8  : 33.20
+      float16 : 30.18
+
+    Single-precision compute (GFLOPS)
+      float   : 451.13
+      float2  : 443.94
+      float4  : 447.42
+      float8  : 445.48
+      float16 : 438.47
+
+    Half-precision compute (GFLOPS)
+      half   : 882.72
+      half2  : 879.14
+      half4  : 887.42
+      half8  : 879.50
+      half16 : 866.43
+
+    Double-precision compute (GFLOPS)
+      double   : 113.61
+      double2  : 112.22
+      double4  : 113.04
+      double8  : 112.07
+      double16 : 109.52
+
+    Integer compute (GIOPS)
+      int   : 151.17
+      int2  : 150.83
+      int4  : 151.24
+      int8  : 150.66
+      int16 : 145.80
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 151.43
+      int2  : 150.85
+      int4  : 151.23
+      int8  : 150.76
+      int16 : 145.71
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 14.48
+      enqueueReadBuffer               : 14.25
+      enqueueWriteBuffer non-blocking : 13.49
+      enqueueReadBuffer non-blocking  : 14.19
+      enqueueMapBuffer(for read)      : 401398.06
+        memcpy from mapped ptr        : 14.16
+      enqueueUnmap(after write)       : 42949592.00
+        memcpy to mapped ptr          : 14.50
+
+    Kernel launch latency : 29.41 us
+

--- a/results/Intel_Graphics_Compute_Runtime/Intel_HD_Graphics_530.log
+++ b/results/Intel_Graphics_Compute_Runtime/Intel_HD_Graphics_530.log
@@ -1,0 +1,61 @@
+
+Platform: Intel(R) OpenCL HD Graphics
+  Device: Intel(R) Graphics Gen9 [0x1912]
+    Driver version  : 20.47.18513 (Linux x64)
+    Compute units   : 23
+    Clock frequency : 950 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 13.74
+      float2  : 14.20
+      float4  : 14.51
+      float8  : 14.82
+      float16 : 15.17
+
+    Single-precision compute (GFLOPS)
+      float   : 327.47
+      float2  : 323.62
+      float4  : 325.96
+      float8  : 323.80
+      float16 : 318.87
+
+    Half-precision compute (GFLOPS)
+      half   : 645.09
+      half2  : 640.47
+      half4  : 644.94
+      half8  : 640.55
+      half16 : 632.08
+
+    Double-precision compute (GFLOPS)
+      double   : 82.26
+      double2  : 81.26
+      double4  : 81.89
+      double8  : 81.28
+      double16 : 79.82
+
+    Integer compute (GIOPS)
+      int   : 109.20
+      int2  : 108.91
+      int4  : 108.98
+      int8  : 108.57
+      int16 : 107.52
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 108.93
+      int2  : 108.83
+      int4  : 109.15
+      int8  : 108.70
+      int16 : 107.40
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 7.07
+      enqueueReadBuffer               : 7.10
+      enqueueWriteBuffer non-blocking : 6.80
+      enqueueReadBuffer non-blocking  : 7.32
+      enqueueMapBuffer(for read)      : 67494.27
+        memcpy from mapped ptr        : 7.09
+      enqueueUnmap(after write)       : 318760.03
+        memcpy to mapped ptr          : 7.10
+
+    Kernel launch latency : 34.17 us
+

--- a/results/Mesa/AMD_Oland_W4170M.log
+++ b/results/Mesa/AMD_Oland_W4170M.log
@@ -1,0 +1,51 @@
+
+Platform: Clover
+  Device: AMD OLAND (DRM 2.50.0, 5.9.12-200.fc33.x86_64, LLVM 11.0.0)
+    Driver version  : 20.2.3 (Linux x64)
+    Compute units   : 6
+    Clock frequency : 900 MHz
+'+fp64-fp16-denormals' is not a recognized feature for this target (ignoring feature)
+'-fp32-denormals' is not a recognized feature for this target (ignoring feature)
+'+fp64-fp16-denormals' is not a recognized feature for this target (ignoring feature)
+'-fp32-denormals' is not a recognized feature for this target (ignoring feature)
+
+    Global memory bandwidth (GBPS)
+      float   : 50.72
+      float2  : 52.88
+      float4  : 54.07
+      float8  : 52.86
+      float16 : 41.40
+
+    Single-precision compute (GFLOPS)
+      float   : 86.08
+      float2  : 86.01
+      float4  : 85.87
+      float8  : 85.72
+      float16 : 85.23
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 43.11
+      double2  : 43.07
+      double4  : 43.00
+      double8  : 42.94
+      double16 : 42.74
+
+    Integer compute (GIOPS)
+      int   : 34.46
+      int2  : 34.43
+      int4  : 34.38
+      int8  : 34.27
+      int16 : 34.37
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer         : 9.07
+      enqueueReadBuffer          : 9.21
+      enqueueMapBuffer(for read) : 9199.74
+        memcpy from mapped ptr   : 9.18
+      enqueueUnmap(after write)  : 10205.28
+        memcpy to mapped ptr     : 9.17
+
+    Kernel launch latency : 199.05 us
+

--- a/results/NVIDIA_CUDA/GeForce_MX_130.log
+++ b/results/NVIDIA_CUDA/GeForce_MX_130.log
@@ -1,0 +1,56 @@
+
+Platform: NVIDIA CUDA
+  Device: GeForce MX130
+    Driver version  : 455.38 (Linux x64)
+    Compute units   : 3
+    Clock frequency : 1189 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 32.25
+      float2  : 33.80
+      float4  : 34.93
+      float8  : 35.33
+      float16 : 25.96
+
+    Single-precision compute (GFLOPS)
+      float   : 573.05
+      float2  : 845.75
+      float4  : 862.53
+      float8  : 857.37
+      float16 : 854.60
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 27.64
+      double2  : 27.63
+      double4  : 27.58
+      double8  : 27.49
+      double16 : 27.28
+
+    Integer compute (GIOPS)
+      int   : 261.52
+      int2  : 290.67
+      int4  : 293.02
+      int8  : 278.32
+      int16 : 267.97
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 261.52
+      int2  : 290.59
+      int4  : 293.09
+      int8  : 291.33
+      int16 : 289.98
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 2.81
+      enqueueReadBuffer               : 3.23
+      enqueueWriteBuffer non-blocking : 2.84
+      enqueueReadBuffer non-blocking  : 3.09
+      enqueueMapBuffer(for read)      : 3.12
+        memcpy from mapped ptr        : 7.80
+      enqueueUnmap(after write)       : 3.11
+        memcpy to mapped ptr          : 7.89
+
+    Kernel launch latency : 7.62 us
+

--- a/results/NVIDIA_CUDA/Quadro_GV100.log
+++ b/results/NVIDIA_CUDA/Quadro_GV100.log
@@ -1,0 +1,56 @@
+
+Platform: NVIDIA CUDA
+  Device: Quadro GV100
+    Driver version  : 455.23.05 (Linux x64)
+    Compute units   : 80
+    Clock frequency : 1627 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 554.70
+      float2  : 575.69
+      float4  : 258.14
+      float8  : 537.39
+      float16 : 552.97
+
+    Single-precision compute (GFLOPS)
+      float   : 6216.30
+      float2  : 11449.58
+      float4  : 14290.00
+      float8  : 7261.11
+      float16 : 7262.70
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 7212.01
+      double2  : 7191.88
+      double4  : 7168.91
+      double8  : 4505.54
+      double16 : 3124.18
+
+    Integer compute (GIOPS)
+      int   : 6219.71
+      int2  : 9340.54
+      int4  : 14371.73
+      int8  : 14373.41
+      int16 : 14342.93
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 9037.88
+      int2  : 6214.77
+      int4  : 6216.47
+      int8  : 9337.87
+      int16 : 14352.44
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 9.75
+      enqueueReadBuffer               : 12.11
+      enqueueWriteBuffer non-blocking : 9.32
+      enqueueReadBuffer non-blocking  : 11.31
+      enqueueMapBuffer(for read)      : 11.25
+        memcpy from mapped ptr        : 9.54
+      enqueueUnmap(after write)       : 11.26
+        memcpy to mapped ptr          : 9.84
+
+    Kernel launch latency : 19.29 us
+

--- a/results/NVIDIA_CUDA/Quadro_P620.log
+++ b/results/NVIDIA_CUDA/Quadro_P620.log
@@ -1,0 +1,56 @@
+
+Platform: NVIDIA CUDA
+  Device: Quadro P620
+    Driver version  : 455.45.01 (Linux x64)
+    Compute units   : 4
+    Clock frequency : 1442 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 79.28
+      float2  : 82.40
+      float4  : 84.20
+      float8  : 82.78
+      float16 : 55.16
+
+    Single-precision compute (GFLOPS)
+      float   : 1357.53
+      float2  : 1400.77
+      float4  : 1397.70
+      float8  : 1390.10
+      float16 : 1385.35
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 45.19
+      double2  : 45.03
+      double4  : 44.97
+      double8  : 44.82
+      double16 : 44.36
+
+    Integer compute (GIOPS)
+      int   : 473.37
+      int2  : 472.65
+      int4  : 473.04
+      int8  : 466.72
+      int16 : 458.70
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 473.50
+      int2  : 473.80
+      int4  : 473.05
+      int8  : 470.43
+      int16 : 468.49
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 11.44
+      enqueueReadBuffer               : 10.75
+      enqueueWriteBuffer non-blocking : 11.12
+      enqueueReadBuffer non-blocking  : 10.50
+      enqueueMapBuffer(for read)      : 11.75
+        memcpy from mapped ptr        : 15.16
+      enqueueUnmap(after write)       : 12.85
+        memcpy to mapped ptr          : 15.27
+
+    Kernel launch latency : 3.50 us
+

--- a/results/NVIDIA_CUDA/Tesla_K80.log
+++ b/results/NVIDIA_CUDA/Tesla_K80.log
@@ -1,0 +1,56 @@
+
+Platform: NVIDIA CUDA
+  Device: Tesla K80
+    Driver version  : 455.32.00 (Linux x64)
+    Compute units   : 13
+    Clock frequency : 823 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 147.19
+      float2  : 148.99
+      float4  : 152.33
+      float8  : 141.67
+      float16 : 68.77
+
+    Single-precision compute (GFLOPS)
+      float   : 2835.78
+      float2  : 2834.16
+      float4  : 3700.81
+      float8  : 3518.41
+      float16 : 3288.67
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 1400.02
+      double2  : 1399.04
+      double4  : 1394.24
+      double8  : 1396.52
+      double16 : 1386.00
+
+    Integer compute (GIOPS)
+      int   : 711.60
+      int2  : 711.39
+      int4  : 711.65
+      int8  : 711.87
+      int16 : 711.75
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 711.52
+      int2  : 711.37
+      int4  : 711.58
+      int8  : 711.36
+      int16 : 709.81
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 9.35
+      enqueueReadBuffer               : 11.89
+      enqueueWriteBuffer non-blocking : 8.42
+      enqueueReadBuffer non-blocking  : 11.13
+      enqueueMapBuffer(for read)      : 9.99
+        memcpy from mapped ptr        : 9.80
+      enqueueUnmap(after write)       : 12.05
+        memcpy to mapped ptr          : 9.57
+
+    Kernel launch latency : 8.20 us
+

--- a/results/NVIDIA_CUDA/Tesla_V100.log
+++ b/results/NVIDIA_CUDA/Tesla_V100.log
@@ -1,0 +1,56 @@
+
+Platform: NVIDIA CUDA
+  Device: Tesla V100-PCIE-32GB
+    Driver version  : 455.23.05 (Linux x64)
+    Compute units   : 80
+    Clock frequency : 1380 MHz
+
+    Global memory bandwidth (GBPS)
+      float   : 716.38
+      float2  : 765.67
+      float4  : 810.35
+      float8  : 723.85
+      float16 : 750.17
+
+    Single-precision compute (GFLOPS)
+      float   : 14098.15
+      float2  : 14135.97
+      float4  : 14095.57
+      float8  : 14049.00
+      float16 : 13934.45
+
+    No half precision support! Skipped
+
+    Double-precision compute (GFLOPS)
+      double   : 7075.81
+      double2  : 7065.56
+      double4  : 7046.01
+      double8  : 7013.68
+      double16 : 6951.51
+
+    Integer compute (GIOPS)
+      int   : 14069.94
+      int2  : 14118.04
+      int4  : 14121.60
+      int8  : 14124.16
+      int16 : 14099.04
+
+    Integer compute Fast 24bit (GIOPS)
+      int   : 14077.32
+      int2  : 14119.12
+      int4  : 14122.14
+      int8  : 14113.63
+      int16 : 14104.60
+
+    Transfer bandwidth (GBPS)
+      enqueueWriteBuffer              : 12.06
+      enqueueReadBuffer               : 10.64
+      enqueueWriteBuffer non-blocking : 10.72
+      enqueueReadBuffer non-blocking  : 8.13
+      enqueueMapBuffer(for read)      : 10.25
+        memcpy from mapped ptr        : 17.55
+      enqueueUnmap(after write)       : 12.59
+        memcpy to mapped ptr          : 18.20
+
+    Kernel launch latency : 7.88 us
+


### PR DESCRIPTION
Signed-off-by: Jan Just Keijser <jan.just.keijser@gmail.com>

Updated results with various Intel, AMD and NVidia hardware:
- Intel i7-10875h CPU
- Intel i7-10875h GPU
- Intel HD Graphics 530 (Intel i7-8550U GPU)
- Intel Xeon Phi 5110
- Intel Xeon Phi 7120
- AMD W4170M 
- AMD Radeon VII Pro
- AMD MI50 PCIe gen3
- AMD MI50 PCIe gen4
- NVidia MX130
- NVidia Quadro P620
- NVidia Quadro GV100
- NVidia Tesla K80
- NVidia Tesla V100