### PR TITLE
options: avoid logger UB during argument parsing

### DIFF
--- a/src/clpeak.cpp
+++ b/src/clpeak.cpp
@@ -28,7 +28,8 @@ clPeak::clPeak() : forcePlatform(false), forcePlatformName(false), forceDevice(f
                    isComputeIntFast(true), isComputeInt(true),
                    isTransferBW(true), isKernelLatency(true), isComputeChar(true), isComputeShort(true),
                    specifiedPlatform(0), specifiedDevice(0),
-                   specifiedPlatformName(0), specifiedDeviceName(0), specifiedTestName(0), specifiedIters(0)
+                   specifiedPlatformName(0), specifiedDeviceName(0), specifiedTestName(0), specifiedIters(0),
+                   log(NULL)
 {
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -31,6 +31,12 @@ static const char *helpStr =
     "\n  -h, --help                  display help message"
     "\n";
 
+static void printParseMessage(const std::string &message)
+{
+  cout << message;
+  cout.flush();
+}
+
 int clPeak::parseArgs(int argc, char **argv)
 {
   bool forcedTests = false;
@@ -41,8 +47,8 @@ int clPeak::parseArgs(int argc, char **argv)
   {
     if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0))
     {
-      log->print(helpStr);
-      log->print(NEWLINE);
+      printParseMessage(helpStr);
+      printParseMessage(NEWLINE);
       exit(0);
     }
     else if ((strcmp(argv[i], "-v") == 0) || (strcmp(argv[i], "--version") == 0))
@@ -50,8 +56,8 @@ int clPeak::parseArgs(int argc, char **argv)
       stringstream versionStr;
       versionStr << "clpeak version: " << VERSION_STR;
 
-      log->print(versionStr.str().c_str());
-      log->print(NEWLINE);
+      printParseMessage(versionStr.str());
+      printParseMessage(NEWLINE);
       exit(0);
     }
     else if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--platform") == 0))
@@ -185,8 +191,8 @@ int clPeak::parseArgs(int argc, char **argv)
     }
     else
     {
-      log->print(helpStr);
-      log->print(NEWLINE);
+      printParseMessage(helpStr);
+      printParseMessage(NEWLINE);
       exit(-1);
     }
   }


### PR DESCRIPTION
Initialize the logger pointer and avoid calling logger methods before the logger object is created.

Help, version and invalid-option output are now printed directly during argument parsing, which keeps the existing behavior without relying on an uninitialized logger.