### PR TITLE
options: include char and short in --all-tests

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -164,7 +164,7 @@ int clPeak::parseArgs(int argc, char **argv)
     }
     else if (strcmp(argv[i], "--all-tests") == 0)
     {
-      isGlobalBW = isComputeHP = isComputeSP = isComputeDP = isComputeInt = isComputeIntFast = isTransferBW = isKernelLatency = true;
+      isGlobalBW = isComputeHP = isComputeSP = isComputeDP = isComputeInt = isComputeIntFast = isComputeChar = isComputeShort = isTransferBW = isKernelLatency = true;
     }
     else if (strcmp(argv[i], "--enable-xml-dump") == 0)
     {


### PR DESCRIPTION
The selective-test reset path disables compute-char and compute-short, but --all-tests was not restoring them.

Re-enable both flags so --all-tests consistently runs the full benchmark set again after any selective test option.