### PR TITLE
Skip kernel latency and event timer on devices without profiling queu…

### DIFF
--- a/src/clpeak.cpp
+++ b/src/clpeak.cpp
@@ -120,7 +120,21 @@ int clPeak::runAll()
           continue;
         }
 
-        cl::CommandQueue queue = cl::CommandQueue(ctx, devices[d], CL_QUEUE_PROFILING_ENABLE);
+        cl_command_queue_properties supportedQueueProps = devices[d].getInfo<CL_DEVICE_QUEUE_PROPERTIES>();
+        bool supportsProfilingQueue = (supportedQueueProps & CL_QUEUE_PROFILING_ENABLE) != 0;
+
+        cl_command_queue_properties queueCreateProps = supportsProfilingQueue ? CL_QUEUE_PROFILING_ENABLE : 0;
+        cl::CommandQueue queue = cl::CommandQueue(ctx, devices[d], queueCreateProps);
+
+        bool savedUseEventTimer = useEventTimer;
+        if (!supportsProfilingQueue)
+        {
+          if (useEventTimer)
+          {
+            log->print(TAB TAB "NOTE: Device does not support profiling queue, --use-event-timer disabled" NEWLINE);
+          }
+          useEventTimer = false;
+        }
 
         runGlobalBandwidthTest(queue, prog, devInfo);
         runComputeSP(queue, prog, devInfo);
@@ -131,7 +145,12 @@ int clPeak::runAll()
         runComputeChar(queue, prog, devInfo);
         runComputeShort(queue, prog, devInfo);
         runTransferBandwidthTest(queue, prog, devInfo);
-        runKernelLatency(queue, prog, devInfo);
+        if (supportsProfilingQueue)
+          runKernelLatency(queue, prog, devInfo);
+        else if (isKernelLatency)
+          log->print(NEWLINE TAB TAB "Kernel launch latency         : Skipped (no profiling queue support)" NEWLINE);
+
+        useEventTimer = savedUseEventTimer;
 
         log->print(NEWLINE);
         log->xmlCloseTag(); // device


### PR DESCRIPTION
…e support

Devices that don't support CL_QUEUE_PROFILING_ENABLE (e.g. Raspberry Pi 5 VideoCore VII via rusticl) would crash with CL_INVALID_QUEUE_PROPERTIES (-35). Now we query CL_DEVICE_QUEUE_PROPERTIES first, create the queue without the profiling flag if unsupported, skip runKernelLatency (which requires profiling info), and disable --use-event-timer for that device with a note to the user.

Fixes #142