### PR TITLE
Use pseudo-random data in buffer population to defeat memory compression

### DIFF
--- a/src/opencl/cl_utils.cpp
+++ b/src/opencl/cl_utils.cpp
@@ -1,4 +1,5 @@
 #include <opencl/cl_utils.h>
+#include <cstring>
 
 uint64_t roundToMultipleOf(uint64_t number, uint64_t base, uint64_t maxValue)
 {
@@ -8,9 +9,22 @@ uint64_t roundToMultipleOf(uint64_t number, uint64_t base, uint64_t maxValue)
 
 void populate(float *ptr, uint64_t N)
 {
+    // Use pseudo-random data to defeat hardware memory compression (some GPUs
+    // transparently compress buffers, inflating apparent bandwidth when the
+    // content is predictable/compressible).
+    uint32_t state = 0xDEADBEEF;
     for (uint64_t i = 0; i < N; i++)
     {
-        ptr[i] = (float)i;
+        // xorshift32
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        // Reinterpret bits as float; mask off sign+exponent high bit to avoid
+        // NaN/Inf (keep exponent in [1,127] range so values are finite).
+        uint32_t bits = (state & 0x7F7FFFFF) | 0x00800000;
+        float val;
+        memcpy(&val, &bits, sizeof(val));
+        ptr[i] = val;
     }
 }
 


### PR DESCRIPTION
Replace sequential float values with xorshift32-generated data in populate(). Some GPUs transparently compress buffers with predictable content, inflating apparent bandwidth in benchmarks. Using pseudo-random bit patterns ensures measured bandwidth reflects actual memory throughput.