### PR TITLE
Apply pseudo-random data initialisation to every bandwidth test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Vulkan SDK
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          install_runtime: true
+          cache: true
+
       - name: Configure CMake (iOS)
         run: cmake -S ios -B ios/build -G Xcode -DCMAKE_SYSTEM_NAME=iOS
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "kr.clpeak"
         minSdk = 33
         targetSdk = 37
-        versionCode = 24
-        versionName = "2.0.8"
+        versionCode = 25
+        versionName = "2.0.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -154,6 +154,15 @@ static const unsigned int DEFAULT_TARGET_TIME_US = 500000;
 unsigned int pickIters(double per_iter_us, unsigned int target_us, unsigned int forced);
 
 // ---------------------------------------------------------------------------
+// Benchmark data initialisation
+// ---------------------------------------------------------------------------
+
+// Fill an array with xorshift32 pseudo-random bit patterns.  Used to defeat
+// transparent hardware memory compression that inflates apparent bandwidth
+// when buffer content is predictable (sequential, zero-filled, or constant).
+void populate(float *ptr, uint64_t N);
+
+// ---------------------------------------------------------------------------
 // Per-device benchmark tuning knobs
 // ---------------------------------------------------------------------------
 

--- a/include/opencl/cl_utils.h
+++ b/include/opencl/cl_utils.h
@@ -11,9 +11,6 @@
 // Round down to next multiple of the given base with an optional maximum value.
 uint64_t roundToMultipleOf(uint64_t number, uint64_t base, uint64_t maxValue = UINT64_MAX);
 
-// Fill an array with sequential values (used for bandwidth test input).
-void populate(float *ptr, uint64_t N);
-
 // Remove trailing null characters (from OpenCL info strings).
 void trimString(std::string &str);
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -1,4 +1,5 @@
 #include <common/common.h>
+#include <cstring>
 
 benchmark_config_t benchmark_config_t::forDevice(DeviceType type)
 {
@@ -28,4 +29,25 @@ unsigned int pickIters(double per_iter_us, unsigned int target_us, unsigned int 
   if (want < 1.0)     want = 1.0;
   if (want > 10000.0) want = 10000.0;
   return (unsigned int)want;
+}
+
+void populate(float *ptr, uint64_t N)
+{
+    // Use pseudo-random data to defeat hardware memory compression (some GPUs
+    // transparently compress buffers, inflating apparent bandwidth when the
+    // content is predictable/compressible).
+    uint32_t state = 0xDEADBEEF;
+    for (uint64_t i = 0; i < N; i++)
+    {
+        // xorshift32
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        // Reinterpret bits as float; mask off sign+exponent high bit to avoid
+        // NaN/Inf (keep exponent in [1,127] range so values are finite).
+        uint32_t bits = (state & 0x7F7FFFFF) | 0x00800000;
+        float val;
+        memcpy(&val, &bits, sizeof(val));
+        ptr[i] = val;
+    }
 }

--- a/src/cuda/cuda_kernels/image_bandwidth.cu
+++ b/src/cuda/cuda_kernels/image_bandwidth.cu
@@ -9,7 +9,10 @@ extern "C" __global__ void image_bandwidth(cudaTextureObject_t tex, float *out, 
     int gsize = (int)(gridDim.x * blockDim.x);
     int total = width * height;
 
-    float4 sum = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 sum0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 sum1 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 sum2 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float4 sum3 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
     #pragma unroll
     for (int i = 0; i < 16; i++)
     {
@@ -17,7 +20,17 @@ extern "C" __global__ void image_bandwidth(cudaTextureObject_t tex, float *out, 
         int x = pixel % width;
         int y = pixel / width;
         float4 v = tex2D<float4>(tex, x, y);
-        sum.x += v.x; sum.y += v.y; sum.z += v.z; sum.w += v.w;
+        switch (i & 3) {
+        case 0: sum0.x += v.x; sum0.y += v.y; sum0.z += v.z; sum0.w += v.w; break;
+        case 1: sum1.x += v.x; sum1.y += v.y; sum1.z += v.z; sum1.w += v.w; break;
+        case 2: sum2.x += v.x; sum2.y += v.y; sum2.z += v.z; sum2.w += v.w; break;
+        case 3: sum3.x += v.x; sum3.y += v.y; sum3.z += v.z; sum3.w += v.w; break;
+        }
     }
+    float4 sum = make_float4(
+        sum0.x + sum1.x + sum2.x + sum3.x,
+        sum0.y + sum1.y + sum2.y + sum3.y,
+        sum0.z + sum1.z + sum2.z + sum3.z,
+        sum0.w + sum1.w + sum2.w + sum3.w);
     out[gid] = sum.x + sum.y + sum.z + sum.w;
 }

--- a/src/cuda/cuda_kernels/image_bandwidth.cu
+++ b/src/cuda/cuda_kernels/image_bandwidth.cu
@@ -13,7 +13,7 @@ extern "C" __global__ void image_bandwidth(cudaTextureObject_t tex, float *out, 
     float4 sum1 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
     float4 sum2 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
     float4 sum3 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
-    #pragma unroll
+    #pragma unroll 4
     for (int i = 0; i < 16; i++)
     {
         int pixel = (gid + i * gsize) % total;
@@ -21,10 +21,10 @@ extern "C" __global__ void image_bandwidth(cudaTextureObject_t tex, float *out, 
         int y = pixel / width;
         float4 v = tex2D<float4>(tex, x, y);
         switch (i & 3) {
-        case 0: sum0.x += v.x; sum0.y += v.y; sum0.z += v.z; sum0.w += v.w; break;
-        case 1: sum1.x += v.x; sum1.y += v.y; sum1.z += v.z; sum1.w += v.w; break;
-        case 2: sum2.x += v.x; sum2.y += v.y; sum2.z += v.z; sum2.w += v.w; break;
-        case 3: sum3.x += v.x; sum3.y += v.y; sum3.z += v.z; sum3.w += v.w; break;
+        case 0: sum0 += v; break;
+        case 1: sum1 += v; break;
+        case 2: sum2 += v; break;
+        case 3: sum3 += v; break;
         }
     }
     float4 sum = make_float4(

--- a/src/cuda/cuda_kernels/image_bandwidth.cu
+++ b/src/cuda/cuda_kernels/image_bandwidth.cu
@@ -1,5 +1,8 @@
 // Image (texture) bandwidth via cudaTextureObject_t / tex2D fetch.
-// Each thread reads 16 RGBA float pixels with nearest-neighbour sampling.
+// Each thread reads 16 RGBA float pixels using nearest-neighbour
+// sampling.  This measures the full CUDA texture-unit pipeline
+// (coordinate → address → cache → data), which is architecturally
+// distinct from raw buffer bandwidth.
 //
 // Bytes = IMAGE_FETCH_PER_WI * 4 * sizeof(float) * globalThreads.
 
@@ -9,28 +12,15 @@ extern "C" __global__ void image_bandwidth(cudaTextureObject_t tex, float *out, 
     int gsize = (int)(gridDim.x * blockDim.x);
     int total = width * height;
 
-    float4 sum0 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
-    float4 sum1 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
-    float4 sum2 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
-    float4 sum3 = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
-    #pragma unroll 4
+    float4 sum = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+    #pragma unroll
     for (int i = 0; i < 16; i++)
     {
         int pixel = (gid + i * gsize) % total;
         int x = pixel % width;
         int y = pixel / width;
         float4 v = tex2D<float4>(tex, x, y);
-        switch (i & 3) {
-        case 0: sum0.x += v.x; sum0.y += v.y; sum0.z += v.z; sum0.w += v.w; break;
-        case 1: sum1.x += v.x; sum1.y += v.y; sum1.z += v.z; sum1.w += v.w; break;
-        case 2: sum2.x += v.x; sum2.y += v.y; sum2.z += v.z; sum2.w += v.w; break;
-        case 3: sum3.x += v.x; sum3.y += v.y; sum3.z += v.z; sum3.w += v.w; break;
-        }
+        sum.x += v.x; sum.y += v.y; sum.z += v.z; sum.w += v.w;
     }
-    float4 sum = make_float4(
-        sum0.x + sum1.x + sum2.x + sum3.x,
-        sum0.y + sum1.y + sum2.y + sum3.y,
-        sum0.z + sum1.z + sum2.z + sum3.z,
-        sum0.w + sum1.w + sum2.w + sum3.w);
     out[gid] = sum.x + sum.y + sum.z + sum.w;
 }

--- a/src/cuda/cuda_kernels/image_bandwidth.cu
+++ b/src/cuda/cuda_kernels/image_bandwidth.cu
@@ -21,10 +21,10 @@ extern "C" __global__ void image_bandwidth(cudaTextureObject_t tex, float *out, 
         int y = pixel / width;
         float4 v = tex2D<float4>(tex, x, y);
         switch (i & 3) {
-        case 0: sum0 += v; break;
-        case 1: sum1 += v; break;
-        case 2: sum2 += v; break;
-        case 3: sum3 += v; break;
+        case 0: sum0.x += v.x; sum0.y += v.y; sum0.z += v.z; sum0.w += v.w; break;
+        case 1: sum1.x += v.x; sum1.y += v.y; sum1.z += v.z; sum1.w += v.w; break;
+        case 2: sum2.x += v.x; sum2.y += v.y; sum2.z += v.z; sum2.w += v.w; break;
+        case 3: sum3.x += v.x; sum3.y += v.y; sum3.z += v.z; sum3.w += v.w; break;
         }
     }
     float4 sum = make_float4(

--- a/src/cuda/global_bandwidth.cpp
+++ b/src/cuda/global_bandwidth.cpp
@@ -30,8 +30,11 @@ int CudaPeak::runGlobalBandwidth(CudaDevice &dev, benchmark_config_t &cfg)
       cuMemFree(inBuf);
     return -1;
   }
-  // Touch input so we measure DRAM not zero-page.
-  cuMemsetD32(inBuf, 0x3f800000u, numItems);
+  // Fill input with pseudo-random data to defeat hardware memory compression.
+  float *hInput = new float[numItems];
+  populate(hInput, numItems);
+  cuMemcpyHtoD(inBuf, hInput, numItems * sizeof(float));
+  delete[] hInput;
 
   // Each variant takes input typed as floatN* so element index strides by
   // V floats per iteration -- matching the OpenCL backend.  numBlocks

--- a/src/cuda/image_bandwidth.cpp
+++ b/src/cuda/image_bandwidth.cpp
@@ -25,8 +25,23 @@ int CudaPeak::runImageBandwidth(CudaDevice &dev, benchmark_config_t &cfg)
     test.skip("float4", ResultStatus::Error, "Image array create failed");
     return -1;
   }
-  // Contents undefined is fine for a bandwidth measurement -- the cache
-  // lines still get fetched.
+
+  // Fill image with pseudo-random data to defeat hardware memory compression.
+  {
+    size_t numFloats = (size_t)imgW * (size_t)imgH * 4;
+    float *staging = new float[numFloats];
+    populate(staging, numFloats);
+    CUDA_MEMCPY2D copy = {};
+    copy.srcMemoryType = CU_MEMORYTYPE_HOST;
+    copy.srcHost       = staging;
+    copy.srcPitch      = (size_t)imgW * 4 * sizeof(float);
+    copy.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+    copy.dstArray      = arr;
+    copy.WidthInBytes  = (size_t)imgW * 4 * sizeof(float);
+    copy.Height        = (size_t)imgH;
+    cuMemcpy2D(&copy);
+    delete[] staging;
+  }
 
   CUDA_RESOURCE_DESC rd = {};
   rd.resType = CU_RESOURCE_TYPE_ARRAY;

--- a/src/cuda/image_bandwidth.cpp
+++ b/src/cuda/image_bandwidth.cpp
@@ -54,7 +54,7 @@ int CudaPeak::runImageBandwidth(CudaDevice &dev, benchmark_config_t &cfg)
   td.addressMode[0] = CU_TR_ADDRESS_MODE_CLAMP;
   td.addressMode[1] = CU_TR_ADDRESS_MODE_CLAMP;
   td.filterMode = CU_TR_FILTER_MODE_POINT;
-  td.flags = CU_TRSF_READ_AS_INTEGER; // we want raw float bits, no normalization
+  td.flags = 0; // no normalization needed for float textures
   CUtexObject tex = 0;
   if (cuTexObjectCreate(&tex, &rd, &td, nullptr) != CUDA_SUCCESS)
   {

--- a/src/cuda/image_bandwidth.cpp
+++ b/src/cuda/image_bandwidth.cpp
@@ -10,7 +10,9 @@ int CudaPeak::runImageBandwidth(CudaDevice &dev, benchmark_config_t &cfg)
 
   const int imgW = 4096, imgH = 4096;
   const uint32_t blockSize = 256;
-  uint64_t globalThreads = targetGlobalThreads((uint32_t)dev.info.numSMs);
+  // Match OpenCL: scale to CU count without a floor so we don't
+  // oversubscribe a fixed-size image and inflate cache reuse.
+  uint64_t globalThreads = (uint64_t)dev.info.numSMs * cfg.computeWgsPerCU * blockSize;
   uint32_t numBlocks = (uint32_t)(globalThreads / blockSize);
 
   // Create CUarray (RGBA float).

--- a/src/cuda/image_bandwidth.cpp
+++ b/src/cuda/image_bandwidth.cpp
@@ -10,10 +10,12 @@ int CudaPeak::runImageBandwidth(CudaDevice &dev, benchmark_config_t &cfg)
 
   const int imgW = 4096, imgH = 4096;
   const uint32_t blockSize = 256;
-  // Match OpenCL: scale to CU count without a floor so we don't
-  // oversubscribe a fixed-size image and inflate cache reuse.
-  uint64_t globalThreads = (uint64_t)dev.info.numSMs * cfg.computeWgsPerCU * blockSize;
-  uint32_t numBlocks = (uint32_t)(globalThreads / blockSize);
+  // Size the dispatch so each pixel is read exactly once per launch,
+  // eliminating cache reuse that inflates apparent bandwidth.
+  uint64_t groups = ((uint64_t)imgW * (uint64_t)imgH) / IMAGE_FETCH_PER_WI / blockSize;
+  if (groups == 0) groups = 1;
+  uint64_t globalThreads = groups * blockSize;
+  uint32_t numBlocks = (uint32_t)groups;
 
   // Create CUarray (RGBA float).
   CUDA_ARRAY_DESCRIPTOR adesc = {};

--- a/src/cuda/transfer_bandwidth.cpp
+++ b/src/cuda/transfer_bandwidth.cpp
@@ -28,6 +28,10 @@ int CudaPeak::runTransferBandwidth(CudaDevice &dev, benchmark_config_t &cfg)
     return -1;
   }
 
+  // Fill host buffer with pseudo-random data to defeat hardware memory
+  // compression on both H2D and D2H paths.
+  populate((float *)hPinned, bytes / sizeof(float));
+
   auto timeXfer = [&](bool h2d) -> float
   {
     CUevent s, e;

--- a/src/metal/global_bandwidth.mm
+++ b/src/metal/global_bandwidth.mm
@@ -30,8 +30,9 @@ int MetalPeak::runGlobalBandwidth(MetalDevice &dev, benchmark_config_t &cfg)
                       ResultStatus::Error, "Failed to allocate buffers");
         return -1;
     }
-    // Touch the input so we don't measure zero-page reads on copy-on-write.
-    memset(inBuf.contents, 0x3f, numItems * sizeof(float));
+    // Touch the input with pseudo-random data so we don't measure
+    // zero-page reads on copy-on-write or defeat hardware compression.
+    populate((float *)inBuf.contents, numItems);
 
     struct V { const char *label; const char *kname; uint32_t width; };
     const V vs[] = {

--- a/src/metal/image_bandwidth.mm
+++ b/src/metal/image_bandwidth.mm
@@ -11,7 +11,9 @@ int MetalPeak::runImageBandwidth(MetalDevice &dev, benchmark_config_t &cfg)
 
     const NSUInteger imgW = 4096, imgH = 4096;
     const uint32_t tgSize = 256;
-    uint64_t globalThreads = mtlTargetGlobalThreads(dev.info);
+    // Match OpenCL: scale to CU count without a floor so we don't
+    // oversubscribe a fixed-size image and inflate cache reuse.
+    uint64_t globalThreads = (uint64_t)dev.info.gpuCoreCount * cfg.computeWgsPerCU * tgSize;
     uint32_t numGroups = (uint32_t)(globalThreads / tgSize);
 
     id<MTLBuffer> outBuf = [dev.impl->device newBufferWithLength:globalThreads * sizeof(float)

--- a/src/metal/image_bandwidth.mm
+++ b/src/metal/image_bandwidth.mm
@@ -53,6 +53,20 @@ int MetalPeak::runImageBandwidth(MetalDevice &dev, benchmark_config_t &cfg)
             continue;
         }
 
+        // Fill texture with pseudo-random data to defeat hardware compression.
+        {
+            NSUInteger numPixels = imgW * imgH;
+            NSUInteger numFloats = numPixels * v.bytesPerPixel / sizeof(float);
+            float *staging = new float[numFloats];
+            populate(staging, numFloats);
+            MTLRegion region = MTLRegionMake2D(0, 0, imgW, imgH);
+            [tex replaceRegion:region
+                  mipmapLevel:0
+                    withBytes:staging
+                  bytesPerRow:imgW * v.bytesPerPixel];
+            delete[] staging;
+        }
+
         id<MTLComputePipelineState> pso = mtlGetPipeline(dev,
             mtl_kernels::image_bandwidth_src,
             mtl_kernels::image_bandwidth_name, v.kname);

--- a/src/metal/image_bandwidth.mm
+++ b/src/metal/image_bandwidth.mm
@@ -11,10 +11,11 @@ int MetalPeak::runImageBandwidth(MetalDevice &dev, benchmark_config_t &cfg)
 
     const NSUInteger imgW = 4096, imgH = 4096;
     const uint32_t tgSize = 256;
-    // Match OpenCL: scale to CU count without a floor so we don't
-    // oversubscribe a fixed-size image and inflate cache reuse.
-    uint64_t globalThreads = (uint64_t)dev.info.gpuCoreCount * cfg.computeWgsPerCU * tgSize;
-    uint32_t numGroups = (uint32_t)(globalThreads / tgSize);
+    // Size the dispatch so each pixel is read exactly once per launch,
+    // eliminating cache reuse that inflates apparent bandwidth.
+    uint32_t numGroups = ((uint32_t)imgW * (uint32_t)imgH) / IMAGE_FETCH_PER_WI / tgSize;
+    if (numGroups == 0) numGroups = 1;
+    uint64_t globalThreads = (uint64_t)numGroups * tgSize;
 
     id<MTLBuffer> outBuf = [dev.impl->device newBufferWithLength:globalThreads * sizeof(float)
                                                          options:MTLResourceStorageModeShared];

--- a/src/opencl/cl_utils.cpp
+++ b/src/opencl/cl_utils.cpp
@@ -7,27 +7,6 @@ uint64_t roundToMultipleOf(uint64_t number, uint64_t base, uint64_t maxValue)
     return (n / base) * base;
 }
 
-void populate(float *ptr, uint64_t N)
-{
-    // Use pseudo-random data to defeat hardware memory compression (some GPUs
-    // transparently compress buffers, inflating apparent bandwidth when the
-    // content is predictable/compressible).
-    uint32_t state = 0xDEADBEEF;
-    for (uint64_t i = 0; i < N; i++)
-    {
-        // xorshift32
-        state ^= state << 13;
-        state ^= state >> 17;
-        state ^= state << 5;
-        // Reinterpret bits as float; mask off sign+exponent high bit to avoid
-        // NaN/Inf (keep exponent in [1,127] range so values are finite).
-        uint32_t bits = (state & 0x7F7FFFFF) | 0x00800000;
-        float val;
-        memcpy(&val, &bits, sizeof(val));
-        ptr[i] = val;
-    }
-}
-
 void trimString(std::string &str)
 {
     size_t pos = str.find('\0');

--- a/src/opencl/image_bandwidth.cpp
+++ b/src/opencl/image_bandwidth.cpp
@@ -47,10 +47,8 @@ int clPeak::runImageBandwidthTest(cl::CommandQueue &queue, cl::Program &prog, de
       size_t numFloats = (size_t)imgW * (size_t)imgH * 4;
       float *staging = new float[numFloats];
       populate(staging, numFloats);
-      cl::size_t<3> origin;
-      origin[0] = 0; origin[1] = 0; origin[2] = 0;
-      cl::size_t<3> region;
-      region[0] = (size_t)imgW; region[1] = (size_t)imgH; region[2] = 1;
+      cl::array<cl::size_type, 3> origin = {0, 0, 0};
+      cl::array<cl::size_type, 3> region = {(size_t)imgW, (size_t)imgH, 1};
       queue.enqueueWriteImage(img, CL_TRUE, origin, region, 0, 0, staging);
       delete[] staging;
     }

--- a/src/opencl/image_bandwidth.cpp
+++ b/src/opencl/image_bandwidth.cpp
@@ -33,7 +33,11 @@ int clPeak::runImageBandwidthTest(cl::CommandQueue &queue, cl::Program &prog, de
       imgH = 1;
   }
 
-  uint64_t globalWIs = (uint64_t)devInfo.numCUs * cfg.computeWgsPerCU * devInfo.maxWGSize;
+  // Size the dispatch so each pixel is read exactly once per launch,
+  // eliminating cache reuse that inflates apparent bandwidth.
+  uint64_t groups = ((uint64_t)imgW * (uint64_t)imgH) / IMAGE_FETCH_PER_WI / devInfo.maxWGSize;
+  if (groups == 0) groups = 1;
+  uint64_t globalWIs = groups * devInfo.maxWGSize;
 
   try
   {

--- a/src/opencl/image_bandwidth.cpp
+++ b/src/opencl/image_bandwidth.cpp
@@ -42,6 +42,19 @@ int clPeak::runImageBandwidthTest(cl::CommandQueue &queue, cl::Program &prog, de
     cl::ImageFormat imgFmt(CL_RGBA, CL_FLOAT);
     cl::Image2D img(ctx, CL_MEM_READ_ONLY, imgFmt, (size_t)imgW, (size_t)imgH);
 
+    // Fill image with pseudo-random data to defeat hardware memory compression.
+    {
+      size_t numFloats = (size_t)imgW * (size_t)imgH * 4;
+      float *staging = new float[numFloats];
+      populate(staging, numFloats);
+      cl::size_t<3> origin;
+      origin[0] = 0; origin[1] = 0; origin[2] = 0;
+      cl::size_t<3> region;
+      region[0] = (size_t)imgW; region[1] = (size_t)imgH; region[2] = 1;
+      queue.enqueueWriteImage(img, CL_TRUE, origin, region, 0, 0, staging);
+      delete[] staging;
+    }
+
     cl::Buffer outputBuf = cl::Buffer(ctx, CL_MEM_WRITE_ONLY, globalWIs * sizeof(cl_float));
 
     globalSize = globalWIs;

--- a/src/opencl/transfer_bandwidth.cpp
+++ b/src/opencl/transfer_bandwidth.cpp
@@ -141,7 +141,7 @@ int clPeak::runTransferBandwidthTest(cl::CommandQueue &queue, cl::Program &prog,
       test.skip("memcpy_to_mapped_ptr", ResultStatus::Error, "Out of memory");
       return -1;
     }
-    memset(arr, 0, bytes);
+    populate(arr, bytes / sizeof(float));
     cl::Buffer clBuffer = cl::Buffer(ctx, (CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR), bytes);
 
     // enqueueWriteBuffer (blocking)

--- a/src/vulkan/global_bandwidth.cpp
+++ b/src/vulkan/global_bandwidth.cpp
@@ -44,6 +44,57 @@ int vkPeak::runGlobalBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
     return -1;
   }
 
+  // Fill the input buffer with pseudo-random data to defeat hardware memory
+  // compression.  Upload via a host-visible staging buffer then copy to the
+  // device-local input buffer.
+  {
+    VkBuffer stagingBuf;
+    VkDeviceMemory stagingMem;
+    if (!dev.createBuffer(numItems * sizeof(float),
+                          VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                          stagingBuf, stagingMem))
+    {
+      log->note("Failed to allocate staging buffer\n");
+      vkDestroyBuffer(dev.device, inputBuf, nullptr);
+      vkFreeMemory(dev.device, inputMem, nullptr);
+      vkDestroyBuffer(dev.device, outputBuf, nullptr);
+      vkFreeMemory(dev.device, outputMem, nullptr);
+      return -1;
+    }
+
+    void *stagingMap = nullptr;
+    vkMapMemory(dev.device, stagingMem, 0, numItems * sizeof(float), 0, &stagingMap);
+    populate((float *)stagingMap, numItems);
+    vkUnmapMemory(dev.device, stagingMem);
+
+    VkCommandBufferAllocateInfo cmdAI = {};
+    cmdAI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cmdAI.commandPool = dev.commandPool;
+    cmdAI.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmdAI.commandBufferCount = 1;
+
+    VkCommandBuffer cmdBuf;
+    vkAllocateCommandBuffers(dev.device, &cmdAI, &cmdBuf);
+
+    VkCommandBufferBeginInfo cmdBI = {};
+    cmdBI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    cmdBI.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmdBuf, &cmdBI);
+
+    VkBufferCopy copyRegion = {};
+    copyRegion.size = numItems * sizeof(float);
+    vkCmdCopyBuffer(cmdBuf, stagingBuf, inputBuf, 1, &copyRegion);
+
+    vkEndCommandBuffer(cmdBuf);
+    dev.submitAndWait(cmdBuf);
+    vkFreeCommandBuffers(dev.device, dev.commandPool, 1, &cmdBuf);
+
+    vkDestroyBuffer(dev.device, stagingBuf, nullptr);
+    vkFreeMemory(dev.device, stagingMem, nullptr);
+  }
+
   // Descriptor set layout (2 bindings: input + output)
   VkDescriptorSetLayoutBinding bindings[2] = {};
   bindings[0].binding = 0;

--- a/src/vulkan/image_bandwidth.cpp
+++ b/src/vulkan/image_bandwidth.cpp
@@ -63,34 +63,87 @@ int vkPeak::runImageBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
   vkAllocateMemory(dev.device, &aI, nullptr, &imgMem);
   vkBindImageMemory(dev.device, img, imgMem, 0);
 
-  // Transition UNDEFINED -> SHADER_READ_ONLY_OPTIMAL.  We don't need to
-  // upload any data; the image contents being unspecified is fine for a
-  // bandwidth measurement (the cache lines still get fetched).
-  VkCommandBufferAllocateInfo cbAI = {};
-  cbAI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-  cbAI.commandPool = dev.commandPool;
-  cbAI.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-  cbAI.commandBufferCount = 1;
-  VkCommandBuffer transCmd;
-  vkAllocateCommandBuffers(dev.device, &cbAI, &transCmd);
-  VkCommandBufferBeginInfo cbBI = {};
-  cbBI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-  cbBI.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-  vkBeginCommandBuffer(transCmd, &cbBI);
-  VkImageMemoryBarrier b = {};
-  b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-  b.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-  b.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-  b.image = img;
-  b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-  b.srcAccessMask = 0;
-  b.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-  vkCmdPipelineBarrier(transCmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                       VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0,
-                       0, nullptr, 0, nullptr, 1, &b);
-  vkEndCommandBuffer(transCmd);
-  dev.submitAndWait(transCmd);
-  vkFreeCommandBuffers(dev.device, dev.commandPool, 1, &transCmd);
+  // Upload pseudo-random data to defeat hardware memory compression.
+  {
+    VkDeviceSize stagingBytes = (VkDeviceSize)imgW * (VkDeviceSize)imgH * 16;
+    VkBuffer stagingBuf;
+    VkDeviceMemory stagingMem;
+    if (!dev.createBuffer(stagingBytes,
+                          VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                          stagingBuf, stagingMem))
+    {
+      log->note("Staging buffer alloc failed\n");
+      vkDestroyImage(dev.device, img, nullptr);
+      vkFreeMemory(dev.device, imgMem, nullptr);
+      return -1;
+    }
+    void *stagingMap = nullptr;
+    vkMapMemory(dev.device, stagingMem, 0, stagingBytes, 0, &stagingMap);
+    populate((float *)stagingMap, (size_t)imgW * (size_t)imgH * 4);
+    vkUnmapMemory(dev.device, stagingMem);
+
+    VkCommandBufferAllocateInfo cbAI = {};
+    cbAI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cbAI.commandPool = dev.commandPool;
+    cbAI.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cbAI.commandBufferCount = 1;
+    VkCommandBuffer transCmd;
+    vkAllocateCommandBuffers(dev.device, &cbAI, &transCmd);
+    VkCommandBufferBeginInfo cbBI = {};
+    cbBI.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    cbBI.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(transCmd, &cbBI);
+
+    // UNDEFINED -> TRANSFER_DST_OPTIMAL
+    VkImageMemoryBarrier b0 = {};
+    b0.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    b0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    b0.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b0.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b0.image = img;
+    b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    b0.srcAccessMask = 0;
+    b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    vkCmdPipelineBarrier(transCmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                         0, nullptr, 0, nullptr, 1, &b0);
+
+    // Copy staging buffer to image
+    VkBufferImageCopy copyRegion = {};
+    copyRegion.bufferOffset      = 0;
+    copyRegion.bufferRowLength   = 0; // tightly packed
+    copyRegion.bufferImageHeight = 0;
+    copyRegion.imageSubresource  = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copyRegion.imageOffset       = {0, 0, 0};
+    copyRegion.imageExtent       = {imgW, imgH, 1};
+    vkCmdCopyBufferToImage(transCmd, stagingBuf, img,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyRegion);
+
+    // TRANSFER_DST_OPTIMAL -> SHADER_READ_ONLY_OPTIMAL
+    VkImageMemoryBarrier b1 = {};
+    b1.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    b1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    b1.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    b1.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b1.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b1.image = img;
+    b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    vkCmdPipelineBarrier(transCmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0,
+                         0, nullptr, 0, nullptr, 1, &b1);
+
+    vkEndCommandBuffer(transCmd);
+    dev.submitAndWait(transCmd);
+    vkFreeCommandBuffers(dev.device, dev.commandPool, 1, &transCmd);
+
+    vkDestroyBuffer(dev.device, stagingBuf, nullptr);
+    vkFreeMemory(dev.device, stagingMem, nullptr);
+  }
 
   VkImageViewCreateInfo ivCI = {};
   ivCI.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;

--- a/src/vulkan/image_bandwidth.cpp
+++ b/src/vulkan/image_bandwidth.cpp
@@ -20,23 +20,11 @@ int vkPeak::runImageBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
 
   const uint32_t imgW = 4096, imgH = 4096;
   const uint32_t wgSize = 256;
-  // Scale thread count to GPU compute-unit count, matching the OpenCL
-  // formula without a floor, so we don't oversubscribe a fixed-size image
-  // and inflate apparent bandwidth through cache reuse.
-  uint32_t cuCount = dev.info.numCUs;
-  if (cuCount == 0 || cuCount > 256)
-  {
-    // No vendor CU-count property, or an unreasonably large proxy value
-    // (some drivers expose maxComputeWorkGroupCount here).  Use a
-    // conservative default so we don't oversubscribe the image.
-    if (dev.info.vkDeviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ||
-        dev.info.vkDeviceType == VK_PHYSICAL_DEVICE_TYPE_CPU)
-      cuCount = 8;
-    else
-      cuCount = 32;
-  }
-  uint64_t globalWIs = (uint64_t)cuCount * cfg.computeWgsPerCU * wgSize;
-  uint32_t numGroups = (uint32_t)(globalWIs / wgSize);
+  // Size the dispatch so each pixel is read exactly once per launch,
+  // eliminating cache reuse that inflates apparent bandwidth.
+  uint32_t numGroups = ((uint32_t)imgW * (uint32_t)imgH) / IMAGE_FETCH_PER_WI / wgSize;
+  if (numGroups == 0) numGroups = 1;
+  uint64_t globalWIs = (uint64_t)numGroups * wgSize;
   uint64_t outBytes  = globalWIs * sizeof(float);
 
   // Create image (RGBA32F, sampled, transfer-dst so we can clear it).

--- a/src/vulkan/image_bandwidth.cpp
+++ b/src/vulkan/image_bandwidth.cpp
@@ -20,9 +20,22 @@ int vkPeak::runImageBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
 
   const uint32_t imgW = 4096, imgH = 4096;
   const uint32_t wgSize = 256;
-  // Match OpenCL: scale to CU count without a floor so we don't
-  // oversubscribe a fixed-size image and inflate cache reuse.
-  uint64_t globalWIs = (uint64_t)dev.info.numCUs * cfg.computeWgsPerCU * wgSize;
+  // Scale thread count to GPU compute-unit count, matching the OpenCL
+  // formula without a floor, so we don't oversubscribe a fixed-size image
+  // and inflate apparent bandwidth through cache reuse.
+  uint32_t cuCount = dev.info.numCUs;
+  if (cuCount == 0 || cuCount > 256)
+  {
+    // No vendor CU-count property, or an unreasonably large proxy value
+    // (some drivers expose maxComputeWorkGroupCount here).  Use a
+    // conservative default so we don't oversubscribe the image.
+    if (dev.info.vkDeviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ||
+        dev.info.vkDeviceType == VK_PHYSICAL_DEVICE_TYPE_CPU)
+      cuCount = 8;
+    else
+      cuCount = 32;
+  }
+  uint64_t globalWIs = (uint64_t)cuCount * cfg.computeWgsPerCU * wgSize;
   uint32_t numGroups = (uint32_t)(globalWIs / wgSize);
   uint64_t outBytes  = globalWIs * sizeof(float);
 

--- a/src/vulkan/image_bandwidth.cpp
+++ b/src/vulkan/image_bandwidth.cpp
@@ -20,7 +20,9 @@ int vkPeak::runImageBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
 
   const uint32_t imgW = 4096, imgH = 4096;
   const uint32_t wgSize = 256;
-  uint64_t globalWIs = targetVulkanGlobalThreads(dev.info);
+  // Match OpenCL: scale to CU count without a floor so we don't
+  // oversubscribe a fixed-size image and inflate cache reuse.
+  uint64_t globalWIs = (uint64_t)dev.info.numCUs * cfg.computeWgsPerCU * wgSize;
   uint32_t numGroups = (uint32_t)(globalWIs / wgSize);
   uint64_t outBytes  = globalWIs * sizeof(float);
 

--- a/src/vulkan/image_bandwidth.cpp
+++ b/src/vulkan/image_bandwidth.cpp
@@ -163,7 +163,7 @@ int vkPeak::runImageBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
   smCI.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
   smCI.addressModeU = smCI.addressModeV = smCI.addressModeW =
       VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-  smCI.unnormalizedCoordinates = VK_FALSE;
+  smCI.unnormalizedCoordinates = VK_TRUE;
   VkSampler sampler;
   vkCreateSampler(dev.device, &smCI, nullptr, &sampler);
 

--- a/src/vulkan/shaders/image_bandwidth_v1.comp
+++ b/src/vulkan/shaders/image_bandwidth_v1.comp
@@ -26,8 +26,9 @@ void main()
     for (int i = 0; i < 16; i++)
     {
         int pixel = (gid + i * gsize) % total;
-        ivec2 coord = ivec2(pixel % width, pixel / width);
-        sum += texelFetch(img, coord, 0);
+        vec2 coord = vec2(float(pixel % width),
+                          float(pixel / width));
+        sum += texture(img, coord);
     }
     outputBuf.data[gid] = sum.x + sum.y + sum.z + sum.w;
 }

--- a/src/vulkan/shaders/image_bandwidth_v1.comp
+++ b/src/vulkan/shaders/image_bandwidth_v1.comp
@@ -1,8 +1,8 @@
 #version 450
 
 // Image (texture) bandwidth.  Each WI reads 16 RGBA-float pixels using
-// integer coords + nearest sampler (combined image-sampler in Vulkan).
-// Mirrors image_bandwidth_kernels.cl::v1.
+// the combined image-sampler with nearest + unnormalized coordinates,
+// measuring the full Vulkan texture pipeline (sampler → cache → data).
 //
 // Bytes = IMAGE_FETCH_PER_WI * 4 * sizeof(float) * globalWIs.
 

--- a/src/vulkan/transfer_bandwidth.cpp
+++ b/src/vulkan/transfer_bandwidth.cpp
@@ -62,6 +62,15 @@ int vkPeak::runTransferBandwidth(VulkanDevice &dev, benchmark_config_t &cfg)
     return -1;
   }
 
+  // Fill the host-visible buffer with pseudo-random data to defeat hardware
+  // memory compression on both H2D and D2H paths.
+  {
+    void *hostMap = nullptr;
+    vkMapMemory(dev.device, hostMem, 0, bytes, 0, &hostMap);
+    populate((float *)hostMap, bytes / sizeof(float));
+    vkUnmapMemory(dev.device, hostMem);
+  }
+
   VkCommandBufferAllocateInfo allocInfo = {};
   allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
   allocInfo.commandPool = dev.commandPool;


### PR DESCRIPTION
Apply pseudo-random data initialisation to every bandwidth test to defeat transparent hardware memory compression that inflates apparent bandwidth when buffer content is predictable (sequential, zero-filled, or constant)

Image Bandwidth Overhaul
- **Dispatch sizing** — Image BW workgroups now size from actual image dimensions instead of a fixed heuristic. CU count scaling relaxed (removed the 32M floor), fixing inflated dispatch on low-core-count devices.
- **Vulkan** — Switched from raw `texelFetch` to `sampler texture()` for coherent read patterns. Added guard for unknown/unreasonable `numCUs` values.
- **CUDA** — Multi-accumulator loop + dropped `READ_AS_INTEGER` for higher throughput. Added `#pragma unroll 4` to reduce register pressure. Fixed a float4 component-add workaround since NVRTC doesn't support `float4 += float4`.