### PR TITLE
CPU backend - run all supported ISA variants

### DIFF
--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -124,6 +124,18 @@ define.
   -ffast-math` deletes the work and reports a fabricated peak. The FMA chains
   use `acc = acc*b + c` with `b<1` (converges to a finite fixed point, no
   inf/denormal) and a *runtime* trip count.
+- **fp32/fp64 affine coefficients (`b`,`c`) must be `volatile`-seeded.** On
+  non-FMA targets (the SSE2 `generic` TU, scalar fallback) `f32_fma`/`f64_fma`
+  are a *transparent* `mul`+`add`, not an opaque hardware FMA. With `b`,`c` as
+  compile-time constants, `-ffast-math` closes the `CPU_UNROLL_K`-unrolled chain
+  — `N` steps of `acc=b*acc+c` fold to `acc*b^N + const` (verified: 4 steps →
+  one `mulps`+`addps`) — deleting most of the work while `opsPerIter` still
+  counts it, so SSE2 reported an impossible peak *above* AVX2. Seeding `b`,`c`
+  through `volatile` (read once into a register before the loop, exactly like
+  the int32 chain's multiplier) blocks the fold and is a no-op on FMA targets
+  (AVX2/AVX-512/NEON keep their real FMAs). This only surfaced once the run-all
+  `kernelMenu()` started exercising the SSE2 fp variant — the old best-only
+  dispatch never ran it.
 - **fp16/bf16 constants must survive narrowing.** `b=0.999999` rounds to exactly
   `1.0` in fp16, making `acc=acc*1+0` invariant → the loop is deleted and fp16
   reports hundreds of TFLOPS. Use values distinct from `1.0`/`0.0` after fp16

--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -16,7 +16,8 @@ local memory, DRAM ↔ global memory.
 - CPU detection (name, cores, cache sizes, ISA flags)? → `cpu_device.cpp`
 - Pinned barrier thread pool? → `thread_pool.cpp`
 - SIMD abstraction (per-ISA vector wrappers)? → `cpu_simd.h`
-- Shared 1T/NT compute runner + gflops/gops emit? → `compute_common.h`
+- Run-all-ISA-variants list / per-ISA labels? → `cpu_dispatch.cpp` (`kernelMenu()`)
+- Shared 1T/NT compute runner + per-ISA test emit (`emitVariants`)? → `compute_common.h`
 - FP compute (fp32/fp64/fp16/bf16/mixed)? → `compute_float.cpp`
 - INT compute (int32, int8 dot)? → `compute_int.cpp`
 - CPU matrix engine (AMX / SMMLA / BFMMLA)? → `cpu_matrix.cpp`
@@ -31,14 +32,14 @@ local memory, DRAM ↔ global memory.
 | `cpu_device.cpp` | `detectCpuInfo()` — brand/vendor (CPUID / sysctl / `/proc/cpuinfo`), core counts (incl. P/E split), L1d/L2/L3 per-instance **and aggregate** (`l3TotalBytes`, from `index3/shared_cpu_list` on Linux / summed on Windows) sizes (sysfs / `GetLogicalProcessorInformationEx` / CPUID; on Apple, `hw.perflevel0.*` for the P-core L1/L2 with a fallback to the generic `hw.*` keys), and ISA flags from compiler feature macros (host-accurate under `-march`/`-mcpu=native`) |
 | `thread_pool.cpp` | `CpuThreadPool`: persistent workers parked on a CV, `run(n, body)` barrier dispatch, per-core pinning (`pthread_setaffinity_np` / `SetThreadAffinityMask`; advisory no-op on macOS) |
 | `cpu_simd.h` | Per-ISA `f32v`/`f64v`/`i32v` wrappers (AVX-512 / AVX2+FMA / SSE2 / NEON / scalar), selected by the *compile flags of the TU it is built in*, with `set`/`load`/`fma`/`add`/`hsum` + a per-ISA accumulator count (`*_NACC`) + `CPU_UNROLL_*` |
-| **`cpu_kernels.h`** | Dispatch API: `CpuFeatures`, `CpuKernelTable` (fn-ptr + opsPerIter per kernel), `cpuFeatures()`, `isaName()`, `kernels()` (best variants for this host) |
+| **`cpu_kernels.h`** | Dispatch API: `CpuFeatures`, `CpuKernelTable` (fn-ptr + opsPerIter per kernel), `cpuFeatures()`, `isaName()`, `kernels()` (best variants — bandwidth only), and `kernelMenu()` returning `CpuKernelMenu` (per-slot `std::vector<IsaVariant>` = **every** supported ISA variant + its canonical label, baseline-first) for the compute tests |
 | **`cpu_kernels_impl.h`** | **All** chain bodies (fp32/fp64/int32/fp16/bf16/mp/int8dp/matrix/readsum), `#if`-gated by compile features, + the per-TU `tuTable()` builder. Included once per feature TU |
 | **`cpu_kernels_tu.cpp`** | Thin TU: `#include cpu_kernels_impl.h` + exports `clpeak_table_<tag>()`. CMake compiles it once per ISA (`generic`, `sse42`, `avx2`, `avx512[vnni\|bf16\|fp16]`, `amx`; `fp16`, `fp16fml`, `dotprod`, `bf16`, `i8mm`; or `native`) with that ISA's flags |
-| **`cpu_dispatch.cpp`** | Runtime feature probe (x86 CPUID+XGETBV / ARM `getauxval` HWCAP / Apple `sysctlbyname`) and `kernels()` assembly — merges supported TUs (`generic` ungated floor, then higher ISA gated on full feature set) picking the widest variant per kernel |
-| `compute_common.h` | `emitCompute()` — runs a chain single-threaded (`ST`) and across all cores (`MT`), emits both metrics |
-| `compute_float.cpp` | `runComputeSP/DP/HP/BF16/MP` methods — look up `kernels().fpXX` and emit (or `Unsupported`). Kernel bodies live in `cpu_kernels_impl.h` |
-| `compute_int.cpp` | `runComputeInt32`/`runComputeInt8DP` (via `kernels()`) |
-| `cpu_matrix.cpp` | `runCpuMatrix` — emits `kernels().mat_int8` / `mat_fp` (AMX / SMMLA / BFMMLA); `Benchmark::Amx`, run in both fp and int phases |
+| **`cpu_dispatch.cpp`** | Runtime feature probe (x86 CPUID+XGETBV / ARM `getauxval` HWCAP / Apple `sysctlbyname`); `kernels()` assembly (merges supported TUs, widest variant per kernel — bandwidth only); and `kernelMenu()` which collects **every** supported variant per kernel with its canonical ISA label (explicit per-slot pushes — encodes the "collapse identical SSE float" rule by pushing only int32 from the `sse42` TU, and labels base vs feature kernels per-slot) |
+| `compute_common.h` | `emitCompute()` — runs a chain single-threaded (`ST`) and across all cores (`MT`), emits both metrics; `emitVariants()` — runs **every** ISA variant from a `kernelMenu()` slot as its own test (ISA appended to the display name, `isaSlug()` into the tag for unique result keys), or one untagged `Unsupported` test if none |
+| `compute_float.cpp` | `runComputeSP/DP/HP/BF16/MP` — `emitVariants(..., kernelMenu().fpXX, ...)` (one test per supported ISA). Kernel bodies live in `cpu_kernels_impl.h` |
+| `compute_int.cpp` | `runComputeInt32`/`runComputeInt8DP` (via `emitVariants` + `kernelMenu()`) |
+| `cpu_matrix.cpp` | `runCpuMatrix` — `emitVariants(..., kernelMenu().mat_int8 / mat_fp, ...)` (AMX / SMMLA / BFMMLA); `Benchmark::Amx`, run in both fp and int phases |
 | `bandwidth.cpp` | `runDramBandwidth` (STREAM read/copy/triad), `runCacheBandwidth` (per-level L1/L2/L3, ST+MT, shared-cache MT sets split across threads). The read kernel is `kernels().readsum`; DRAM arrays sized off the **aggregate** L3 (`pickStreamFloats`) + parallel first-touch for NUMA-local placement. No `TransferBW`/memcpy test — on a CPU it just re-measures the STREAM copy path |
 | `latency.cpp` | `runMemoryLatency` (random pointer-chase per cache level, ns) |
 
@@ -52,6 +53,16 @@ local memory, DRAM ↔ global memory.
   `--memory-latency`) on that macro.
 
 ## ISA strategy — per-TU build + runtime dispatch
+
+**Compute tests run EVERY supported ISA variant, not just the best.** The compute
+methods iterate `kernelMenu()` and emit a separate test per ISA — header decorated
+with the canonical label, e.g. `Single-precision compute (SSE2)`,
+`… (AVX2+FMA)`, `… (AVX-512)` — so users can compare instruction sets. Each ISA's
+tag is slugged (`single_precision_compute_avx_512`) so dump/baseline rows stay
+unique. fp32/fp64 SSE2 and SSE4.2 codegen is identical, so the `sse42` TU
+contributes only its (genuinely different) int32 variant — no duplicate SSE float
+row. Bandwidth still uses the single best kernel via `kernels().readsum`, and the
+device-header `ISA:` property is still the widest active ISA (`isaName()`).
 
 Two build modes, selected by `CLPEAK_CPU_NATIVE_ARCH` (default OFF):
 
@@ -95,14 +106,17 @@ Windows ARM64 the kernel-exported AArch64 ID registers in the registry
 (`CentralProcessor\0` values `CP 4020`/`CP 4030`/`CP 4031` =
 `ID_AA64PFR0/ISAR0/ISAR1_EL1`; there is no `IsProcessorFeaturePresent()`
 constant for most of these features). `cpu_device.cpp`
-fills `info.has*` / `isaName` from this same probe, and methods gate on
-`kernels().<x>.fn != nullptr` (so the `Unsupported` rows reflect the run host).
+fills `info.has*` / `isaName` from this same probe, and the compute tests emit an
+`Unsupported` row when a `kernelMenu()` slot is empty (so the skips reflect the run
+host).
 
 Adding a TU: add a `clpeak_add_isa_tu(<tag> <flags>)` call in `CMakeLists.txt`
-(guarded by `check_cxx_compiler_flag`) and a matching `#if CLPEAK_TU_<tag>` merge
-(with the right feature predicate) in `cpu_dispatch.cpp`. The kernel bodies are
-shared — `cpu_kernels_impl.h` `#if`-gates them on the compile-feature macros the
-TU's flags define.
+(guarded by `check_cxx_compiler_flag`), a matching `#if CLPEAK_TU_<tag>` merge in
+`kernels()` (best-variant, bandwidth), **and** a `#if CLPEAK_TU_<tag>` push in
+`kernelMenu()` (with the right feature predicate + the canonical ISA label) so the
+new ISA shows up as its own compute test. The kernel bodies are shared —
+`cpu_kernels_impl.h` `#if`-gates them on the compile-feature macros the TU's flags
+define.
 
 ## Gotchas
 

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -220,7 +220,12 @@ else()
             if(_clpeak_f_fp16x)
                 clpeak_add_isa_tu(avx512fp16 ${_avx512_core} ${_clpeak_gnuflag}-mavx512fp16)
             endif()
-            if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            # AMX is a 64-bit-only ISA: GCC/clang accept the -mamx-* flags in
+            # 32-bit mode (so check_cxx_compiler_flag passes), but <immintrin.h>
+            # only declares the _tile_* intrinsics under #ifdef __x86_64__, so an
+            # i686 build would compile the AMX TU and then fail with "_tile_loadd
+            # was not declared".  Gate on a 64-bit target.
+            if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
                 set(_amx ${_avx512_core} -mamx-tile -mamx-int8 -mamx-bf16)
                 check_cxx_compiler_flag("${_amx}" _clpeak_f_amx)
                 if(_clpeak_f_amx)

--- a/src/cpu/compute_common.h
+++ b/src/cpu/compute_common.h
@@ -5,7 +5,9 @@
 
 #include <cpu/cpu_peak.h>
 #include <common/result_store.h>
+#include "cpu_kernels.h"
 
+#include <cctype>
 #include <string>
 #include <vector>
 
@@ -47,6 +49,52 @@ static void emitCompute(CpuPeak &peak, logger::TestScope &test,
 
   if (usN > 0.0) test.emit(label + " MT", giga(opsPerIterPerThread, maxT, usN));
   else           test.skip(label + " MT", ResultStatus::Error, "workload failed");
+}
+
+// Canonical ISA label -> tag suffix, e.g. "AVX-512" -> "avx_512",
+// "AVX2+FMA" -> "avx2_fma".  Lowercased; each run of non-alphanumeric chars
+// becomes a single '_'.  Appended to the test tag so each ISA's rows stay
+// unique in the dump / baseline files.
+static inline std::string isaSlug(const std::string &isa)
+{
+  std::string s;
+  bool pendingSep = false;
+  for (char c : isa)
+  {
+    if (std::isalnum((unsigned char)c))
+    {
+      if (pendingSep && !s.empty()) s += '_';
+      pendingSep = false;
+      s += (char)std::tolower((unsigned char)c);
+    }
+    else
+      pendingSep = true;
+  }
+  return s;
+}
+
+// Run EVERY supported ISA variant of one compute kernel: a separate test (with
+// its own header) per variant, the ISA appended to the display name and slugged
+// into the tag.  If no variant is supported, emit one untagged Unsupported test.
+static void emitVariants(CpuPeak &peak, const logger::TestSpec &base,
+                         const std::string &metric,
+                         const std::vector<clpeak_cpu::IsaVariant> &vars,
+                         const char *unsupReason, benchmark_config_t &cfg)
+{
+  if (vars.empty())
+  {
+    auto test = peak.currentDeviceScope->beginTest(base);
+    test.skip(metric + " ST", ResultStatus::Unsupported, unsupReason);
+    return;
+  }
+  for (const auto &iv : vars)
+  {
+    logger::TestSpec spec = base;
+    spec.tag     = base.tag + "_" + isaSlug(iv.isa);
+    spec.display = base.display + " (" + iv.isa + ")";
+    auto test = peak.currentDeviceScope->beginTest(spec);
+    emitCompute(peak, test, metric, iv.v.opsPerIter, iv.v.fn, cfg);
+  }
 }
 
 #endif // ENABLE_CPU

--- a/src/cpu/compute_float.cpp
+++ b/src/cpu/compute_float.cpp
@@ -9,49 +9,40 @@
 // cpu_kernels_tu.cpp and selected at runtime; here we just look up the chosen
 // variant and emit (or record Unsupported when no variant exists for this CPU).
 
-using clpeak_cpu::kernels;
-
-static void runChain(CpuPeak &peak, const logger::TestSpec &spec, const char *metric,
-                     const clpeak_cpu::ChainVariant &v, const char *unsupReason,
-                     benchmark_config_t &cfg)
-{
-  auto test = peak.currentDeviceScope->beginTest(spec);
-  if (v.fn) emitCompute(peak, test, metric, v.opsPerIter, v.fn, cfg);
-  else      test.skip(metric, ResultStatus::Unsupported, unsupReason);
-}
+using clpeak_cpu::kernelMenu;
 
 int CpuPeak::runComputeSP(benchmark_config_t &cfg)
 {
-  runChain(*this, {"single_precision_compute", "Single-precision compute", "gflops"},
-           "float", kernels().fp32, "no SIMD fp32 path for this CPU", cfg);
+  emitVariants(*this, {"single_precision_compute", "Single-precision compute", "gflops"},
+               "float", kernelMenu().fp32, "no SIMD fp32 path for this CPU", cfg);
   return 0;
 }
 
 int CpuPeak::runComputeDP(benchmark_config_t &cfg)
 {
-  runChain(*this, {"double_precision_compute", "Double-precision compute", "gflops"},
-           "double", kernels().fp64, "no SIMD fp64 path for this CPU", cfg);
+  emitVariants(*this, {"double_precision_compute", "Double-precision compute", "gflops"},
+               "double", kernelMenu().fp64, "no SIMD fp64 path for this CPU", cfg);
   return 0;
 }
 
 int CpuPeak::runComputeHP(benchmark_config_t &cfg)
 {
-  runChain(*this, {"half_precision_compute", "Half-precision compute", "gflops"},
-           "half", kernels().fp16, "no native fp16 arithmetic on this CPU", cfg);
+  emitVariants(*this, {"half_precision_compute", "Half-precision compute", "gflops"},
+               "half", kernelMenu().fp16, "no native fp16 arithmetic on this CPU", cfg);
   return 0;
 }
 
 int CpuPeak::runComputeBF16(benchmark_config_t &cfg)
 {
-  runChain(*this, {"bfloat16_compute", "BF16 compute bf16xbf16+fp32", "gflops"},
-           "bf16", kernels().bf16, "no bf16 dot instruction on this CPU", cfg);
+  emitVariants(*this, {"bfloat16_compute", "BF16 compute bf16xbf16+fp32", "gflops"},
+               "bf16", kernelMenu().bf16, "no bf16 dot instruction on this CPU", cfg);
   return 0;
 }
 
 int CpuPeak::runComputeMP(benchmark_config_t &cfg)
 {
-  runChain(*this, {"mixed_precision_compute", "Mixed-precision compute fp16xfp16+fp32", "gflops"},
-           "mp", kernels().mp, "no conversion-free fp16xfp16+fp32 widening FMA on this CPU", cfg);
+  emitVariants(*this, {"mixed_precision_compute", "Mixed-precision compute fp16xfp16+fp32", "gflops"},
+               "mp", kernelMenu().mp, "no conversion-free fp16xfp16+fp32 widening FMA on this CPU", cfg);
   return 0;
 }
 

--- a/src/cpu/compute_int.cpp
+++ b/src/cpu/compute_int.cpp
@@ -5,26 +5,19 @@
 #include "cpu_kernels.h"
 #include "compute_common.h"
 
-#include <string>
-
-using clpeak_cpu::kernels;
+using clpeak_cpu::kernelMenu;
 
 int CpuPeak::runComputeInt32(benchmark_config_t &cfg)
 {
-  auto test = currentDeviceScope->beginTest({"integer_compute", "Integer compute", "gops"});
-  const auto &v = kernels().int32;
-  if (v.fn) emitCompute(*this, test, "int", v.opsPerIter, v.fn, cfg);
-  else      test.skip("int", ResultStatus::Unsupported, "no SIMD int32 path for this CPU");
+  emitVariants(*this, {"integer_compute", "Integer compute", "gops"},
+               "int", kernelMenu().int32, "no SIMD int32 path for this CPU", cfg);
   return 0;
 }
 
 int CpuPeak::runComputeInt8DP(benchmark_config_t &cfg)
 {
-  auto test = currentDeviceScope->beginTest(
-    {"int8_dot_product_compute", "INT8 dot-product compute", "gops"});
-  const auto &v = kernels().int8dp;
-  if (v.fn) emitCompute(*this, test, "int8_dp", v.opsPerIter, v.fn, cfg);
-  else      test.skip("int8_dp", ResultStatus::Unsupported, "no int8 dot instruction on this CPU");
+  emitVariants(*this, {"int8_dot_product_compute", "INT8 dot-product compute", "gops"},
+               "int8_dp", kernelMenu().int8dp, "no int8 dot instruction on this CPU", cfg);
   return 0;
 }
 

--- a/src/cpu/cpu_dispatch.cpp
+++ b/src/cpu/cpu_dispatch.cpp
@@ -407,11 +407,13 @@ const CpuKernelMenu &kernelMenu()
     {
       const CpuKernelTable *t = clpeak_table_bf16();
       add(m.bf16, t->bf16, "NEON BF16");
-      add(m.mat_fp, t->mat_fp, "NEON BF16");   // BFMMLA is part of FEAT_BF16
+      // Matrix engine: tag with the matrix instruction itself (BFMMLA, part of
+      // FEAT_BF16) rather than the feature name, paralleling x86 "AMX".
+      add(m.mat_fp, t->mat_fp, "BFMMLA");
     }
 #endif
 #if CLPEAK_TU_i8mm
-    if (f.i8mm) add(m.mat_int8, clpeak_table_i8mm()->mat_int8, "NEON I8MM");
+    if (f.i8mm) add(m.mat_int8, clpeak_table_i8mm()->mat_int8, "SMMLA");  // FEAT_I8MM matrix instr
 #endif
 #endif // CLPEAK_NATIVE_BUILD
     return m;

--- a/src/cpu/cpu_dispatch.cpp
+++ b/src/cpu/cpu_dispatch.cpp
@@ -306,6 +306,119 @@ const CpuKernelTable &kernels()
   return sel;
 }
 
+// ---- Run-all menu: every supported variant, baseline-first -----------------
+// Unlike kernels() (which merges down to the single widest variant per kernel),
+// this exposes ALL supported ISA variants so the compute tests can report each
+// one separately.  Labels are the canonical isaName() style.  The "collapse
+// identical SSE float" rule is encoded by only pushing int32 (not fp32/fp64)
+// from the sse42 TU: SSE4.2 fp32/fp64 codegen is identical to the SSE2 floor.
+const CpuKernelMenu &kernelMenu()
+{
+  static CpuKernelMenu menu = [] {
+    CpuKernelMenu m{};
+    const CpuFeatures &f = cpuFeatures();
+    (void)f;
+
+    auto add = [](std::vector<IsaVariant> &vec, const ChainVariant &v, const char *isa) {
+      if (v.fn) vec.push_back({v, isa});
+    };
+    // Push the base dtypes (fp32/fp64/int32) a tier TU provides, all one label.
+    auto addBase = [&](const CpuKernelTable *t, const char *isa) {
+      add(m.fp32, t->fp32, isa);
+      add(m.fp64, t->fp64, isa);
+      add(m.int32, t->int32, isa);
+    };
+
+#if CLPEAK_NATIVE_BUILD
+    // Single native TU: trust build==run host, label everything the runtime ISA.
+    const CpuKernelTable *t = clpeak_table_native();
+    const char *isa = isaName();
+    addBase(t, isa);
+    add(m.fp16, t->fp16, isa);
+    add(m.bf16, t->bf16, isa);
+    add(m.mp, t->mp, isa);
+    add(m.int8dp, t->int8dp, isa);
+    add(m.mat_int8, t->mat_int8, isa);
+    add(m.mat_fp, t->mat_fp, isa);
+#else
+    // ---- x86 tier TUs (base dtypes) ----
+#if CLPEAK_TU_generic
+    // The ungated floor: SSE2 on x86, NEON on aarch64, scalar elsewhere.
+#if defined(CLPEAK_X86)
+    const char *genIsa = "SSE2";
+#elif defined(CLPEAK_ARM) && (defined(__aarch64__) || defined(_M_ARM64))
+    const char *genIsa = "NEON";
+#else
+    const char *genIsa = "scalar";
+#endif
+    {
+      const CpuKernelTable *t = clpeak_table_generic();
+      addBase(t, genIsa);
+      // On Apple the generic (apple-m1) floor also carries the advanced NEON
+      // dtypes; push whatever it actually provides, labeled by feature.
+      if (f.fp16)    add(m.fp16, t->fp16, "NEON FP16");
+      if (f.dotprod) add(m.int8dp, t->int8dp, "NEON DotProd");
+      if (f.fp16fml) add(m.mp, t->mp, "NEON FP16FML");
+    }
+#endif
+#if CLPEAK_TU_sse42
+    if (f.sse42) add(m.int32, clpeak_table_sse42()->int32, "SSE4.2");  // fp32/fp64 == SSE2
+#endif
+#if CLPEAK_TU_avx2
+    if (f.avx2 && f.fma) addBase(clpeak_table_avx2(), "AVX2+FMA");
+#endif
+#if CLPEAK_TU_avx512
+    if (f.avx512f && f.avx512bw && f.avx512vl && f.avx512dq)
+      addBase(clpeak_table_avx512(), "AVX-512");
+#endif
+    // ---- x86 feature TUs (advanced dtypes only) ----
+#if CLPEAK_TU_avx512vnni
+    if (f.avx512f && f.avx512bw && f.avx512vl && f.avx512vnni)
+      add(m.int8dp, clpeak_table_avx512vnni()->int8dp, "AVX-512 VNNI");
+#endif
+#if CLPEAK_TU_avx512bf16
+    if (f.avx512f && f.avx512bw && f.avx512vl && f.avx512bf16)
+      add(m.bf16, clpeak_table_avx512bf16()->bf16, "AVX-512 BF16");
+#endif
+#if CLPEAK_TU_avx512fp16
+    if (f.avx512f && f.avx512bw && f.avx512vl && f.avx512fp16)
+      add(m.fp16, clpeak_table_avx512fp16()->fp16, "AVX-512 FP16");
+#endif
+#if CLPEAK_TU_amx
+    if (f.amx_tile && f.amx_int8 && f.amx_bf16 && amxPermOk())
+    {
+      const CpuKernelTable *t = clpeak_table_amx();
+      add(m.mat_int8, t->mat_int8, "AMX");
+      add(m.mat_fp, t->mat_fp, "AMX");
+    }
+#endif
+    // ---- ARM feature TUs (advanced dtypes only; base == generic NEON) ----
+#if CLPEAK_TU_fp16
+    if (f.fp16) add(m.fp16, clpeak_table_fp16()->fp16, "NEON FP16");
+#endif
+#if CLPEAK_TU_fp16fml
+    if (f.fp16fml) add(m.mp, clpeak_table_fp16fml()->mp, "NEON FP16FML");
+#endif
+#if CLPEAK_TU_dotprod
+    if (f.dotprod) add(m.int8dp, clpeak_table_dotprod()->int8dp, "NEON DotProd");
+#endif
+#if CLPEAK_TU_bf16
+    if (f.bf16)
+    {
+      const CpuKernelTable *t = clpeak_table_bf16();
+      add(m.bf16, t->bf16, "NEON BF16");
+      add(m.mat_fp, t->mat_fp, "NEON BF16");   // BFMMLA is part of FEAT_BF16
+    }
+#endif
+#if CLPEAK_TU_i8mm
+    if (f.i8mm) add(m.mat_int8, clpeak_table_i8mm()->mat_int8, "NEON I8MM");
+#endif
+#endif // CLPEAK_NATIVE_BUILD
+    return m;
+  }();
+  return menu;
+}
+
 } // namespace clpeak_cpu
 
 #endif // ENABLE_CPU

--- a/src/cpu/cpu_kernels.h
+++ b/src/cpu/cpu_kernels.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 // ===========================================================================
 // Runtime ISA dispatch.  The compute / read kernels are compiled once per
@@ -48,8 +49,28 @@ struct CpuKernelTable {
   const char  *isaName = "";
 };
 
-// The best kernels for THIS host (assembled once on first call).
+// The best kernels for THIS host (assembled once on first call).  Used by the
+// bandwidth path (readsum), which is memory-bound and only needs one variant.
 const CpuKernelTable &kernels();
+
+// One compute variant tagged with its canonical ISA label (e.g. "AVX-512").
+// The label lives here, not in ChainVariant, so it can differ per kernel slot
+// for the same TU (a feature TU's int8dp is "AVX-512 VNNI" while its base fp32
+// would be "AVX-512").
+struct IsaVariant {
+  ChainVariant v;
+  const char  *isa = "";
+};
+
+// ALL supported variants of each compute kernel for THIS host, baseline-first
+// (low ISA -> high ISA).  The compute tests run every entry so the user can
+// compare instruction sets, rather than only the widest one (see kernels()).
+struct CpuKernelMenu {
+  std::vector<IsaVariant> fp32, fp64, int32, fp16, bf16, mp, int8dp, mat_int8, mat_fp;
+};
+
+// Assembled once on first call.
+const CpuKernelMenu &kernelMenu();
 
 } // namespace clpeak_cpu
 

--- a/src/cpu/cpu_kernels_impl.h
+++ b/src/cpu/cpu_kernels_impl.h
@@ -32,8 +32,16 @@ using namespace cpu_simd;
 static double runFp32Chain(uint64_t outer)
 {
   f32v acc[F32_NACC];
-  const f32v b = f32_set(0.999999f);
-  const f32v c = f32_set(0.000001f);
+  // Seed the coefficients through volatile so the compiler can't prove their
+  // values and close the affine recurrence acc=acc*b+c.  On non-FMA targets
+  // (SSE2 / scalar) f32_fma is a transparent mul+add; with -ffast-math the
+  // CPU_UNROLL_K-unrolled chain would otherwise fold N steps into one
+  // (acc*b^N + const), deleting most of the work while opsPerIter still counts
+  // it -> an impossible peak (SSE2 reported > AVX2).  Same guard as the int32
+  // chain.  No-op on FMA targets (b/c become runtime operands loaded once).
+  volatile float vb = 0.999999f, vc = 0.000001f;
+  const f32v b = f32_set(vb);
+  const f32v c = f32_set(vc);
   for (int j = 0; j < F32_NACC; j++) acc[j] = f32_set(0.1f * (float)(j + 1));
   for (uint64_t o = 0; o < outer; o++)
     CPU_UNROLL_K
@@ -50,8 +58,11 @@ static double runFp32Chain(uint64_t outer)
 static double runFp64Chain(uint64_t outer)
 {
   f64v acc[F64_NACC];
-  const f64v b = f64_set(0.999999);
-  const f64v c = f64_set(0.000001);
+  // Volatile-seed the coefficients to keep the affine chain from collapsing on
+  // non-FMA (SSE2 / scalar) targets under -ffast-math.  See runFp32Chain.
+  volatile double vb = 0.999999, vc = 0.000001;
+  const f64v b = f64_set(vb);
+  const f64v c = f64_set(vc);
   for (int j = 0; j < F64_NACC; j++) acc[j] = f64_set(0.1 * (double)(j + 1));
   for (uint64_t o = 0; o < outer; o++)
     CPU_UNROLL_K

--- a/src/cpu/cpu_kernels_impl.h
+++ b/src/cpu/cpu_kernels_impl.h
@@ -19,7 +19,7 @@
 #define CLPEAK_ISA_NAME_STR "scalar"
 #endif
 
-#if (defined(__AMX_INT8__) || defined(__AMX_BF16__)) && defined(__linux__)
+#if (defined(__AMX_INT8__) || defined(__AMX_BF16__)) && defined(__linux__) && defined(__x86_64__)
 #include <immintrin.h>
 #endif
 
@@ -421,7 +421,7 @@ static double runInt8DpChain(uint64_t outer)
 
 // ---- Matrix engine: int8 (AMX / SMMLA) and bf16 (AMX / BFMMLA) -------------
 // ops are PER-k; the table multiplies by INNER (the chain loops INNER per outer).
-#if defined(__AMX_INT8__) && defined(__linux__)
+#if defined(__AMX_INT8__) && defined(__linux__) && defined(__x86_64__)
 #define CPU_MAT_INT8_KERNEL 1
 static constexpr double MAT_I8_OPS_PER_K = 4.0 * 16 * 16 * 64 * 2;
 static thread_local bool g_amxI8Cfg = false;
@@ -476,7 +476,7 @@ static double runMatInt8Chain(uint64_t outer)
 }
 #endif
 
-#if defined(__AMX_BF16__) && defined(__linux__)
+#if defined(__AMX_BF16__) && defined(__linux__) && defined(__x86_64__)
 #define CPU_MAT_FP_KERNEL 1
 static constexpr double MAT_FP_OPS_PER_K = 4.0 * 16 * 16 * 32 * 2;
 static thread_local bool g_amxBf16Cfg = false;

--- a/src/cpu/cpu_matrix.cpp
+++ b/src/cpu/cpu_matrix.cpp
@@ -9,27 +9,21 @@
 // (ARM).  The variant is compiled per-ISA and selected at runtime; run in both
 // the fp (bf16) and int (int8) phases like the GPU tensor tests.
 
-using clpeak_cpu::kernels;
+using clpeak_cpu::kernelMenu;
 
 int CpuPeak::runCpuMatrix(benchmark_config_t &cfg, Category category)
 {
   if (category == Category::FpCompute)
   {
-    auto test = currentDeviceScope->beginTest(
-      {"cpu_matrix_fp", "CPU matrix engine (bf16)", "gflops"});
-    const auto &v = kernels().mat_fp;
-    if (v.fn) emitCompute(*this, test, "matrix_bf16", v.opsPerIter, v.fn, cfg);
-    else      test.skip("matrix_bf16", ResultStatus::Unsupported,
-                        "no CPU bf16 matrix engine (AMX / BFMMLA) on this CPU");
+    emitVariants(*this, {"cpu_matrix_fp", "CPU matrix engine (bf16)", "gflops"},
+                 "matrix_bf16", kernelMenu().mat_fp,
+                 "no CPU bf16 matrix engine (AMX / BFMMLA) on this CPU", cfg);
     return 0;
   }
 
-  auto test = currentDeviceScope->beginTest(
-    {"cpu_matrix_int", "CPU matrix engine (int8)", "gops"});
-  const auto &v = kernels().mat_int8;
-  if (v.fn) emitCompute(*this, test, "matrix_int8", v.opsPerIter, v.fn, cfg);
-  else      test.skip("matrix_int8", ResultStatus::Unsupported,
-                      "no CPU int8 matrix engine (AMX / I8MM) on this CPU");
+  emitVariants(*this, {"cpu_matrix_int", "CPU matrix engine (int8)", "gops"},
+               "matrix_int8", kernelMenu().mat_int8,
+               "no CPU int8 matrix engine (AMX / I8MM) on this CPU", cfg);
   return 0;
 }
 


### PR DESCRIPTION
- **Expose every supported CPU ISA variant as its own compute test** — `kernelMenu()` collects all supported instruction sets per compute kernel (baseline-first); `emitVariants()` runs each variant as a separate test with its ISA label (e.g. "Single-precision compute (SSE2)", "(AVX2+FMA)", "(AVX-512)") so users can compare instruction sets. Bandwidth path unchanged (still uses single best kernel).

- **Volatile-seed fp32/fp64 affine coefficients** — fixes an `-ffast-math` bug where the unrolled chain collapsed into one op on non-FMA targets (SSE2/scalar), causing an impossible peak above AVX2. Seeds `b`/`c` through `volatile` to block the fold; no-op on FMA targets.

- **Gate AMX intrinsics on 64-bit target** — fixes compilation on i686 where AMX types are unavailable. Fixes #173 