### PR TITLE
cmake: install the binary into GNUInstallDirs bindir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,8 +267,7 @@ endforeach()
 message(STATUS "===============================================================")
 message(STATUS "")
 
-install(TARGETS clpeak RUNTIME DESTINATION .)
-install(FILES LICENSE DESTINATION .)
+install(TARGETS clpeak RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 enable_testing()
 add_test(clpeak_test_run clpeak)
 


### PR DESCRIPTION
The packaging rework changed the install rule to drop the binary directly into the install prefix root (`DESTINATION .`) so the CPack ZIP keeps it at the archive root.

That breaks a normal system install: the binary ends up as `/usr/clpeak` instead of `/usr/bin/clpeak`, so distro packages (openSUSE, and anyone else installing into a real prefix) that expect it under bindir fail to build.

`GNUInstallDirs` is already included, so this just honours it for the binary target. The CPack ZIP still gets a sensible `bin/clpeak` layout under its toplevel directory.