### PR TITLE
Add CUDA support for sm_103, sm_110, and sm_121

### DIFF
--- a/include/cuda/cuda_peak.h
+++ b/include/cuda/cuda_peak.h
@@ -43,8 +43,15 @@ struct cuda_device_info_t {
   bool wmmaSupported;            // cc >= 7.0 (Volta) -- fp16 wmma
   bool wmmaInt8Supported;        // cc >= 7.2 (Turing) -- int8 wmma fragments
   bool fp8MmaSupported;          // cc >= 8.9 (Ada) -- inline mma.sync.e4m3/e5m2
-  bool fp4MmaSupported;          // cc >= 12.0 (Blackwell) -- sm_120a mma FP4/MXFP4
-  bool fp4MmaSparseSupported;    // cc >= 12.0 (Blackwell) -- sm_120a mma.sp FP4 2:4
+  bool fp4MmaSupported;          // cc 12.x (consumer Blackwell) -- sm_120a/121a
+                                 // raw mma.sync FP4/MXFP4 microbench kernels
+  bool fp4MmaSparseSupported;    // cc 12.x (consumer Blackwell) -- sm_120a/121a
+                                 // raw mma.sp FP4 2:4 microbench kernels
+  bool fp4GemmSupported;         // cc >= 10.0 (all Blackwell) -- block-scaled
+                                 // FP4 GEMM via cuBLASLt; covers datacenter
+                                 // (sm_100/103, tcgen05) too, where the raw
+                                 // mma.sync kernels above do not apply. cuBLASLt
+                                 // self-skips (0 heuristics) if truly absent.
   bool tf32GemmSupported;        // cc >= 8.0 (Ampere) -- TF32 tensor cores
   bool int8GemmSupported;        // cc >= 7.5 (Turing) -- imma int8 GEMM
   bool int4GemmSupported;        // cc >= 9.0 (Hopper)  -- imma int4 GEMM

--- a/include/cuda/cuda_peak.h
+++ b/include/cuda/cuda_peak.h
@@ -49,9 +49,9 @@ struct cuda_device_info_t {
   bool int8GemmSupported;        // cc >= 7.5 (Turing) -- imma int8 GEMM
   bool int4GemmSupported;        // cc >= 9.0 (Hopper)  -- imma int4 GEMM
   bool dpTensorSupported;        // cc >= 8.0 (Ampere) -- fp64 wmma m8n8k4
-  bool int4MmaSupported;         // cc 7.5..8.9 (Turing/Ampere/Ada) -- s4 mma.sync;
-                                 // dropped on sm_90+ (Hopper) where the s4 imma
-                                 // path was removed.
+  bool int4MmaSupported;         // cc 7.5..8.9 (Turing/Ampere/Ada) + 12.1 (GB10)
+                                 // -- s4 mma.sync; dropped on Hopper/datacenter
+                                 // Blackwell, re-added on consumer Blackwell GB10.
   bool int8MmaSparseSupported;   // cc >= 8.0 (Ampere+) -- mma.sp.s8 2:4 sparsity
 };
 

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 # Kernels are grouped by the compute capabilities they are valid for so nvcc is
 # never asked to target an arch a kernel cannot build for (e.g. fp8 < sm_89,
 # int4 removed on sm_90+, fp4 only on sm_120a).
-set(CLPEAK_CUDA_ARCHS "70;75;80;86;89;90;100;120" CACHE STRING
+set(CLPEAK_CUDA_ARCHS "70;75;80;86;89;90;100;120;121" CACHE STRING
     "CUDA compute capabilities to bake into the fatbins (ascending)")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedCudaKernels.cmake)
@@ -75,8 +75,10 @@ embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH
 embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH 72
     KERNELS wmma_int8)
 
-# INT4 mma.sync -- sm_75..sm_89 only (removed on Hopper+).
-embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH 75 MAX_ARCH 89
+# INT4 mma.sync -- sm_75..sm_89, removed on Hopper/datacenter Blackwell, but
+# re-added on consumer Blackwell sm_121 (GB10); hence the explicit EXTRA_ARCHS
+# after the MAX_ARCH 89 cutoff. (sm_120 not yet listed -- needs verification.)
+embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH 75 MAX_ARCH 89 EXTRA_ARCHS "121"
     KERNELS wmma_int4)
 
 # Ampere+ tensor cores: bf16 / tf32 / fp64 / int8 m16n8k32 + int8 2:4 sparse
@@ -88,8 +90,10 @@ embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH
 embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH 89
     KERNELS wmma_fp8_e4m3 wmma_fp8_e5m2)
 
-# FP4 / MXFP4 / NVFP4 mma.sync (dense + 2:4 sparse) -- Blackwell sm_120a.
+# FP4 / MXFP4 / NVFP4 mma.sync (dense + 2:4 sparse) -- consumer Blackwell
+# sm_120a (RTX 50) and sm_121a (GB10). Datacenter Blackwell (sm_100a/103a) uses
+# the tcgen05 path instead and is not covered by these mma.sync kernels.
 embed_cuda_kernels(TARGET peak_cuda MASTER_ARCHS "${CLPEAK_CUDA_ARCHS}" MIN_ARCH 999
-    EXTRA_ARCHS "120a"
+    EXTRA_ARCHS "120a;121a"
     KERNELS wmma_fp4_e2m1 wmma_mxf4_e2m1 wmma_nvf4_e2m1
             wmma_mxf4_sparse wmma_nvf4_sparse)

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 # Kernels are grouped by the compute capabilities they are valid for so nvcc is
 # never asked to target an arch a kernel cannot build for (e.g. fp8 < sm_89,
 # int4 removed on sm_90+, fp4 only on sm_120a).
-set(CLPEAK_CUDA_ARCHS "70;75;80;86;89;90;100;120;121" CACHE STRING
+set(CLPEAK_CUDA_ARCHS "70;75;80;86;89;90;100;103;120;121" CACHE STRING
     "CUDA compute capabilities to bake into the fatbins (ascending)")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedCudaKernels.cmake)

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 # Kernels are grouped by the compute capabilities they are valid for so nvcc is
 # never asked to target an arch a kernel cannot build for (e.g. fp8 < sm_89,
 # int4 removed on sm_90+, fp4 only on sm_120a).
-set(CLPEAK_CUDA_ARCHS "70;75;80;86;89;90;100;103;120;121" CACHE STRING
+set(CLPEAK_CUDA_ARCHS "70;75;80;86;89;90;100;103;110;120;121" CACHE STRING
     "CUDA compute capabilities to bake into the fatbins (ascending)")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedCudaKernels.cmake)

--- a/src/cuda/cuda_blas.cpp
+++ b/src/cuda/cuda_blas.cpp
@@ -614,9 +614,12 @@ int CudaPeak::runCublas(CudaDevice &dev, benchmark_config_t &cfg, Category categ
 
         // mxfp4 / nvfp4: block-scaled 4-bit GEMM on Blackwell tensor cores.
         // Same dtypes the wmma microbench measures (mxf4_e2m1 / nvf4_e2m1), so
-        // the cublas-fp rows line up against the wmma rows.
+        // the cublas-fp rows line up against the wmma rows.  Gated on
+        // fp4GemmSupported (all Blackwell) rather than fp4MmaSupported (the
+        // consumer-only raw-mma microbench): the library FP4 path runs on
+        // datacenter sm_100/103 as well, and self-skips where it can't.
 #if defined(CLPEAK_CUBLASLT_HAS_FP4)
-        if (dev.info.fp4MmaSupported)
+        if (dev.info.fp4GemmSupported)
         {
             // 0x7F = 1.0 in UE8M0 (exponent-only, bias 127);
             // 0x38 = 1.0 in UE4M3 (e4m3, bias 7).

--- a/src/cuda/cuda_device.cpp
+++ b/src/cuda/cuda_device.cpp
@@ -91,10 +91,11 @@ bool CudaDevice::init(int devIndex)
   info.int4GemmSupported = (info.major >= 9);
   info.dpTensorSupported = (info.major >= 8);
   // s4 mma.sync was added on Turing (sm_75), kept on Ampere/Ada, removed on
-  // Hopper+ (sm_90+).  Allow 7.5..8.9 inclusive.
+  // Hopper and datacenter Blackwell, but re-added on consumer Blackwell GB10
+  // (sm_121).  Allow 7.5..8.9 inclusive, plus 12.1.
   {
     int cc = info.major * 10 + info.minor;
-    info.int4MmaSupported = (cc >= 75) && (cc <= 89);
+    info.int4MmaSupported = ((cc >= 75) && (cc <= 89)) || (cc == 121);
   }
   info.int8MmaSparseSupported = (info.major >= 8);
 

--- a/src/cuda/cuda_device.cpp
+++ b/src/cuda/cuda_device.cpp
@@ -86,6 +86,11 @@ bool CudaDevice::init(int devIndex)
   info.fp8MmaSupported = (info.major >= 9) || (info.major == 8 && info.minor >= 9);
   info.fp4MmaSupported = (info.major >= 12);
   info.fp4MmaSparseSupported = (info.major >= 12);
+  // Block-scaled FP4 GEMM via cuBLASLt exists across the whole Blackwell line
+  // (datacenter sm_100/103 + consumer sm_120/121), unlike the raw mma.sync FP4
+  // microbench which is consumer-only.  cuBLASLt returns 0 heuristics where it
+  // can't actually run, so this gate only decides whether we *attempt* it.
+  info.fp4GemmSupported = (info.major >= 10);
   info.tf32GemmSupported = (info.major >= 8);
   info.int8GemmSupported = (info.major > 7) || (info.major == 7 && info.minor >= 5);
   info.int4GemmSupported = (info.major >= 9);


### PR DESCRIPTION
New GPU coverage

- sm_121 (GB10/DGX Spark) — native SASS fatbins, INT4 mma.sync, FP4 mma.sync (dense + 2:4 sparse)
- sm_103 (Blackwell Ultra B300/GB300) — native SASS instead of sm_100 compat fallback
- sm_110 (Jetson Thor) — zero kernel coverage before; now covered by compute/bandwidth/bf16/fp8/int8 groups

cuBLASLt FP4 on datacenter Blackwell.

Gated cuBLASLt block-scaled FP4 GEMM on new fp4GemmSupported bit (cc ≥ 10.0) instead of fp4MmaSupported (sm_120+), enabling the library path on B100/B200/B300.