### PR TITLE
refactor: move TextLogger from CLI to shared common module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,7 @@ The CLI entry point is `src/cli/main.cpp` with its own `logger.cpp`.
 
 | Path | Purpose |
 |------|---------|
-| `include/common/` | All neutral headers — `peak.h`, `benchmark_enums.h`, `logger.h` (base), etc. |
-| `include/cli/` | CLI-specific headers — `logger_cli.h` |
+| `include/common/` | All neutral headers — `peak.h`, `benchmark_enums.h`, `logger.h` (base), `logger_text.h` (shared text logger), etc. |
 | `include/opencl/` | OpenCL backend headers — `cl_peak.h`, `cl_common.h` |
 | `include/vulkan/` | Vulkan backend header — `vk_peak.h` |
 | `include/cuda/` | CUDA backend header — `cuda_peak.h` |
@@ -42,7 +41,7 @@ The CLI entry point is `src/cli/main.cpp` with its own `logger.cpp`.
 | `src/metal/` | Metal backend: `MetalPeak` class (ObjC++) + `.metal` kernels |
 | `src/oneapi/` | oneAPI/SYCL backend: `OneapiPeak` class + SYCL kernels (inline lambdas, AOT/JIT via DPC++) |
 | `src/cpu/` | Native CPU backend: `CpuPeak` class + `std::thread` pool + per-ISA SIMD kernels (`-march`/`-mcpu=native`); cache/DRAM bandwidth + memory latency |
-| `src/cli/` | Desktop CLI: `main.cpp`, `logger.cpp` (stdout output) |
+| `src/cli/` | Desktop CLI: `main.cpp` |
 | `src/common/cmake/` | Version handling (`version.cmake`, `GenVersion.cmake`, `version.h.in`) |
 | `android/` | Android app (Vulkan, OpenCL, CPU) with JNI native module, its own `logger_android.cpp` |
 | `ios/` | iOS SwiftUI app with Vulkan-over-MoltenVK, Metal, and CPU backends |

--- a/android/app/src/main/cpp/logger_android.cpp
+++ b/android/app/src/main/cpp/logger_android.cpp
@@ -1,23 +1,20 @@
 #include "logger_android.h"
 #include <sstream>
 
-// ── note (no-op: text channel removed) ─────────────────────────────────────
-
-void LoggerAndroid::note(const std::string & /*msg*/)
-{
-    // Text channel is dead — Android UI consumes structured data only.
-}
-
-// ── onDeviceBegin → device_info_callback_from_c ────────────────────────────
+// ── onDeviceBegin → text + device_info_callback_from_c ─────────────────────
 
 void LoggerAndroid::onDeviceBegin(const std::string &name,
                                   const std::string &platform,
                                   const std::string &driverVersion,
                                   const std::vector<Prop> &props,
-                                  bool /*showPlatformLine*/,
+                                  bool showPlatformLine,
                                   int platformIndex,
                                   int deviceIndex)
 {
+    // Emit the formatted device block to logcat.
+    LoggerText::onDeviceBegin(name, platform, driverVersion, props,
+                             showPlatformLine, platformIndex, deviceIndex);
+
     if (!deviceInfoCallback)
         return;
 
@@ -52,10 +49,22 @@ void LoggerAndroid::onDeviceBegin(const std::string &name,
     jEnv->DeleteLocalRef(jDeviceIndex);
 }
 
-// ── onMetricEmitted → record_metric_callback_from_c ────────────────────────
+// ── onTestBegin → text + remember display name for JNI ─────────────────
 
-void LoggerAndroid::onMetricEmitted(const ResultEntry &e, float value, bool /*subMetric*/)
+void LoggerAndroid::onTestBegin(const std::string &tag,
+                                const std::string &display,
+                                const std::string &unit)
 {
+    LoggerText::onTestBegin(tag, display, unit);
+    curDisplay = display;
+}
+
+// ── onMetricEmitted → text + record_metric_callback_from_c ─────────────
+
+void LoggerAndroid::onMetricEmitted(const ResultEntry &e, float value, bool subMetric)
+{
+    LoggerText::onMetricEmitted(e, value, subMetric);
+
     if (!recordMetricCallback)
         return;
 
@@ -90,10 +99,12 @@ void LoggerAndroid::onMetricEmitted(const ResultEntry &e, float value, bool /*su
     jEnv->DeleteLocalRef(jReason);
 }
 
-// ── onMetricSkipped → record_metric_callback_from_c ────────────────────────
+// ── onMetricSkipped → text + record_metric_callback_from_c ─────────────
 
 void LoggerAndroid::onMetricSkipped(const ResultEntry &e)
 {
+    LoggerText::onMetricSkipped(e);
+
     if (!recordMetricCallback)
         return;
 

--- a/android/app/src/main/cpp/logger_android.h
+++ b/android/app/src/main/cpp/logger_android.h
@@ -1,19 +1,80 @@
 #ifndef LOGGER_ANDROID_HPP
 #define LOGGER_ANDROID_HPP
 
-#include <common/logger.h>
+#include <common/logger_text.h>
+#include <android/log.h>
 #include <jni.h>
+#include <ostream>
+#include <streambuf>
+#include <string>
+
+// ── std::ostream → logcat ──────────────────────────────────────────────────
+//
+// The shared text formatter (LoggerText) writes to a std::ostream.  This
+// streambuf buffers characters until a newline (or an explicit flush) and
+// forwards each completed line to logcat under a fixed tag, so the output is
+// filterable in Android Studio / `adb logcat` (e.g. `adb logcat -s clpeak`).
+
+class LogcatStreambuf : public std::streambuf
+{
+public:
+    explicit LogcatStreambuf(const char *tag, int priority = ANDROID_LOG_INFO)
+        : tag(tag), priority(priority) {}
+
+protected:
+    int overflow(int ch) override
+    {
+        if (ch == traits_type::eof())
+            return ch;
+        if (ch == '\n')
+            emitLine();
+        else
+            buffer += static_cast<char>(ch);
+        return ch;
+    }
+
+    // Flush (std::flush / ostream::flush()) emits whatever has accumulated.
+    // The text logger only flushes at line boundaries, so this never splits a
+    // metric line mid-way — it just lets newline-less notes reach logcat.
+    int sync() override
+    {
+        if (!buffer.empty())
+            emitLine();
+        return 0;
+    }
+
+private:
+    void emitLine()
+    {
+        __android_log_write(priority, tag.c_str(), buffer.c_str());
+        buffer.clear();
+    }
+
+    std::string tag;
+    int         priority;
+    std::string buffer;
+};
+
+// Owns the logcat streambuf + ostream.  Declared as a separate base so it is
+// constructed *before* the LoggerText base (base classes initialise in
+// declaration order), letting us hand the ostream to LoggerText's constructor.
+class LogcatChannel
+{
+protected:
+    LogcatStreambuf logcatBuf{"clpeak"};
+    std::ostream    logcatOut{&logcatBuf};
+};
 
 // ── Android logger ─────────────────────────────────────────────────────────
 //
-// Forwards structured data to Java via two JNI callbacks:
+// Reuses the shared text formatter (LoggerText) pointed at logcat, so the text
+// is identical to the CLI app, and additionally forwards structured data to the
+// Kotlin UI via two JNI callbacks:
 //   - record_metric_callback_from_c  — Ok + skipped metrics (extended with
 //                                      status and reason fields)
 //   - device_info_callback_from_c    — device properties (once per device)
-//
-// Text formatting is handled entirely by the Kotlin UI layer.
 
-class LoggerAndroid : public logger
+class LoggerAndroid : private LogcatChannel, public LoggerText
 {
 public:
     JNIEnv   *jEnv = nullptr;
@@ -21,12 +82,10 @@ public:
     jmethodID recordMetricCallback = nullptr;
     jmethodID deviceInfoCallback   = nullptr;
 
-    using logger::logger;
-
-    void note(const std::string &msg) override;
+    LoggerAndroid() : LogcatChannel(), LoggerText(logcatOut) {}
+    ~LoggerAndroid() override { logcatOut.flush(); }
 
 protected:
-    void onBackendBegin(const std::string &name) override           { (void)name; }
     void onDeviceBegin(const std::string &name,
                        const std::string &platform,
                        const std::string &driverVersion,
@@ -36,19 +95,11 @@ protected:
                        int deviceIndex) override;
     void onTestBegin(const std::string &tag,
                      const std::string &display,
-                     const std::string &unit) override {
-        (void)tag; (void)unit;
-        curDisplay = display;
-    }
+                     const std::string &unit) override;
     void onMetricEmitted(const ResultEntry &e,
                          float value,
                          bool subMetric) override;
     void onMetricSkipped(const ResultEntry &e) override;
-    void onTestSkippedAll(ResultStatus status,
-                          const std::string &reason) override       { (void)status; (void)reason; }
-    void onTestEnd() override                                       {}
-    void onDeviceEnd() override                                     {}
-    void onBackendEnd() override                                    {}
 
 private:
     std::string curDisplay;

--- a/include/common/AGENTS.md
+++ b/include/common/AGENTS.md
@@ -10,7 +10,7 @@ No backend-specific includes live here.
 - Looking for benchmark constants + calibration? → `common.h`
 - Looking for CLI options struct? → `options.h`
 - Looking for result output format? → `result_store.h`
-- Looking for logger interface? → `logger.h`
+- Looking for logger interface? → `logger.h` (base) / `logger_text.h` (shared text formatter)
 - Looking for device inventory structs? → `inventory.h`
 - Looking for gating? → `peak.h` (gating is part of Peak)
 
@@ -23,7 +23,8 @@ No backend-specific includes live here.
 | `common.h` | OS macros, tuning constants, `benchmark_config_t`, `pickIters()` calibration |
 | `options.h` | `CliOptions` struct + `parseCliOptions()` declaration |
 | `result_store.h` | `ResultEntry`/`ResultStore` + JSON/CSV/XML serialization |
-| `logger.h` | `logger` class — result-scope API, stdout, baseline compare |
+| `logger.h` | `logger` abstract base — result-scope API, hooks, accumulated `results` |
+| `logger_text.h` | `LoggerText` — indented/aligned text formatting to an injectable `std::ostream` + baseline deltas; shared by CLI + Android |
 | `inventory.h` | `InventoryDevice`, `BackendInventory`, `inventoryToJson()` |
 
 ## When You Change This Directory

--- a/include/common/logger_text.h
+++ b/include/common/logger_text.h
@@ -1,20 +1,29 @@
-#ifndef LOGGER_CLI_HPP
-#define LOGGER_CLI_HPP
+#ifndef LOGGER_TEXT_HPP
+#define LOGGER_TEXT_HPP
 
 #include <common/logger.h>
+#include <iostream>
 #include <vector>
 
-// ── Desktop CLI logger ─────────────────────────────────────────────────────
+// ── Text logger ────────────────────────────────────────────────────────────
 //
-// Formats benchmark output to stdout with automatic indentation, metric-name
-// alignment, and optional baseline-comparison deltas.  Accumulated
-// ResultEntry rows are stored in the base-class `results` member for later
-// file dump (JSON / CSV / XML).
+// Formats benchmark output as indented, column-aligned text with optional
+// baseline-comparison deltas.  Output is written to an injectable std::ostream
+// (defaults to std::cout), so the same formatting drives:
+//   - the desktop CLI (std::cout),
+//   - the Android app (an ostream backed by a logcat streambuf),
+//   - and any future text channel (iOS, file export, …).
+//
+// Accumulated ResultEntry rows are stored in the base-class `results` member
+// for later file dump (JSON / CSV / XML) — see result_store.h.
 
-class LoggerCli : public logger
+class LoggerText : public logger
 {
 public:
-    using logger::logger;  // inherit constructor
+    // `out` is captured by reference and must outlive this logger.
+    explicit LoggerText(std::ostream &out = std::cout,
+                        std::string compareFileName = "")
+        : logger(std::move(compareFileName)), out(out) {}
 
     void note(const std::string &msg) override;
 
@@ -39,6 +48,9 @@ protected:
     void onTestEnd() override;
     void onDeviceEnd() override;
     void onBackendEnd() override;
+
+    // Destination stream for all formatted output.
+    std::ostream &out;
 
 private:
     // ── Indentation state ────────────────────────────────────────────────
@@ -73,4 +85,4 @@ private:
     void printBaselineDelta(const std::string &metric, float value);
 };
 
-#endif // LOGGER_CLI_HPP
+#endif // LOGGER_TEXT_HPP

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -7,18 +7,17 @@ runs benchmarks, and handles centralized file output.
 
 - CLI argument parsing? → `../common/options.cpp` + `include/common/options.h`
 - How backends are wired? → `main.cpp` — creates backend objects, merges results
-- Logger implementation? → `logger_cli.cpp` + `include/cli/logger_cli.h`
+- Logger implementation? → shared `LoggerText` in `../common/logger_text.cpp` + `include/common/logger_text.h` (CLI constructs it over `std::cout`)
 - Device listing? → `main.cpp` — `enumerateAllBackends()` with per-backend printing
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `main.cpp` | `main()` — backend dispatch, `enumerateAllBackends()`, centralized file output |
-| `logger_cli.cpp` | `LoggerCli` — stdout printing, baseline comparison (derives from `logger`) |
+| `main.cpp` | `main()` — backend dispatch, `enumerateAllBackends()`, centralized file output; constructs `LoggerText(std::cout, …)` |
 
 ## When You Change This Directory
 
 - If you add a CLI flag → update `include/common/options.h` + `../common/options.cpp`.
 - If you change how backends are invoked → update `main.cpp`.
-- If you change output format → update `logger.cpp` + `include/common/logger.h`.
+- If you change the text output format → update `../common/logger_text.cpp` (shared by CLI + Android).

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(clpeak
     main.cpp
-    logger_cli.cpp
 )
 # peak_common comes transitively through every backend target
 # Place binary at build root (not under src/cli/)

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -3,7 +3,7 @@
 #include <common/options.h>
 #include <common/inventory.h>
 #include <common/result_store.h>
-#include <cli/logger_cli.h>
+#include <common/logger_text.h>
 #include <functional>
 #include <iostream>
 
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
             continue;
 
         auto peak = be.create();
-        peak->log.reset(new LoggerCli(opts.compareFile));
+        peak->log.reset(new LoggerText(std::cout, opts.compareFile));
         peak->applyOptions(opts);
         int status = peak->runAll();
         mergeResults(combined, peak->log->results);

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -1,9 +1,12 @@
 # src/common — Shared Backend-Neutral Code
 
 Base classes, utilities, result store, and inventory shared
-by every backend. Does NOT contain a logger implementation — each consumer
-(desktop CLI, Android) provides its own (`src/cli/logger_cli.cpp` or
-`android/.../logger_android.cpp`).
+by every backend. Also owns the shared text logger (`logger_text.cpp` —
+`LoggerText`, writes to an injectable `std::ostream`). Consumers that need a
+non-text channel subclass it: the desktop CLI uses `LoggerText` directly over
+`std::cout`; Android (`android/.../logger_android.cpp`) and iOS
+(`ios/.../logger_ios.mm`) subclass to also forward structured data over JNI /
+callbacks.
 
 ## Quick Lookups
 
@@ -23,6 +26,7 @@ by every backend. Does NOT contain a logger implementation — each consumer
 | `common.cpp` | `benchmark_config_t::forDevice()`, `pickIters()` calibration |
 | `result_store.cpp` | `ResultEntry`/`ResultStore` serialization: JSON, CSV, XML |
 | `logger.cpp` | Base `logger` class: result-scope API, `emit()`, `recordSkip` |
+| `logger_text.cpp` | `LoggerText` — indented/aligned text formatting to an injectable `std::ostream` + baseline deltas (derives from `logger`); shared by CLI + Android |
 | `inventory.cpp` | `inventoryToJson()` — device inventory JSON serializer (no backend includes) |
 | `options.cpp` | `parseCliOptions()` — CLI argument parsing |
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -4,13 +4,15 @@ add_library(peak_common STATIC
     dynlib.cpp
     inventory.cpp
     logger.cpp
+    logger_text.cpp
     options.cpp
     result_store.cpp
 )
 # dlopen lives in libdl on older glibc; ${CMAKE_DL_LIBS} is empty where it's in libc.
 target_link_libraries(peak_common PUBLIC ${CMAKE_DL_LIBS})
-# logger.cpp lives in src/cli/ (desktop) or android/ (Android JNI) —
-# each consumer brings its own output implementation.
+# logger.cpp (base) + logger_text.cpp (shared text formatter, writes to an
+# injectable std::ostream) live here.  Consumers that need a non-text channel
+# (Android JNI, iOS callbacks) subclass these in their own tree.
 target_include_directories(peak_common PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/../../include
     ${CMAKE_CURRENT_LIST_DIR}/../../include/common

--- a/src/common/logger_text.cpp
+++ b/src/common/logger_text.cpp
@@ -1,7 +1,6 @@
-#include <cli/logger_cli.h>
+#include <common/logger_text.h>
 #include <algorithm>
 #include <iomanip>
-#include <iostream>
 #include <sstream>
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -10,30 +9,30 @@ static const int MIN_METRIC_PAD = 8;   // minimum column width for metric names
 
 // ── note ───────────────────────────────────────────────────────────────────
 
-void LoggerCli::note(const std::string &msg)
+void LoggerText::note(const std::string &msg)
 {
-    std::cout << msg;
-    std::cout.flush();
+    out << msg;
+    out.flush();
 }
 
 // ── onBackendBegin ─────────────────────────────────────────────────────────
 
-void LoggerCli::onBackendBegin(const std::string &name)
+void LoggerText::onBackendBegin(const std::string &name)
 {
     indentLevel = 0;
-    std::cout << "Backend: " << name << "\n";
-    std::cout.flush();
+    out << "Backend: " << name << "\n";
+    out.flush();
 }
 
 // ── onDeviceBegin ──────────────────────────────────────────────────────────
 
-void LoggerCli::onDeviceBegin(const std::string &name,
-                              const std::string &platform,
-                              const std::string &driverVersion,
-                              const std::vector<Prop> &props,
-                              bool _showPlatformLine,
-                              int platformIndex,
-                              int deviceIndex)
+void LoggerText::onDeviceBegin(const std::string &name,
+                               const std::string &platform,
+                               const std::string &driverVersion,
+                               const std::vector<Prop> &props,
+                               bool _showPlatformLine,
+                               int platformIndex,
+                               int deviceIndex)
 {
     showPlatformLine = _showPlatformLine;
 
@@ -74,16 +73,16 @@ void LoggerCli::onDeviceBegin(const std::string &name,
         writeLine(propIndent, line);
     }
 
-    std::cout.flush();
+    out.flush();
 }
 
 // ── onTestBegin ────────────────────────────────────────────────────────────
 
-void LoggerCli::onTestBegin(const std::string & /*tag*/,
-                            const std::string &display,
-                            const std::string &unit)
+void LoggerText::onTestBegin(const std::string & /*tag*/,
+                             const std::string &display,
+                             const std::string &unit)
 {
-    std::cout << "\n";
+    out << "\n";
 
     metricIndent = propIndent + 1;   // metrics indented one more than props
     indentLevel  = propIndent;       // test header at prop level
@@ -100,12 +99,12 @@ void LoggerCli::onTestBegin(const std::string & /*tag*/,
 
     writeLine(header);
     metricLines.clear();
-    std::cout.flush();
+    out.flush();
 }
 
 // ── onMetricEmitted ────────────────────────────────────────────────────────
 
-void LoggerCli::onMetricEmitted(const ResultEntry &e, float value, bool subMetric)
+void LoggerText::onMetricEmitted(const ResultEntry &e, float value, bool subMetric)
 {
     metricLines.push_back({MetricLine::Ok, e.metric, value,
                            ResultStatus::Ok, "", subMetric});
@@ -113,7 +112,7 @@ void LoggerCli::onMetricEmitted(const ResultEntry &e, float value, bool subMetri
 
 // ── onMetricSkipped ────────────────────────────────────────────────────────
 
-void LoggerCli::onMetricSkipped(const ResultEntry &e)
+void LoggerText::onMetricSkipped(const ResultEntry &e)
 {
     metricLines.push_back({MetricLine::Skipped, e.metric, 0.0f,
                            e.status, e.reason, false});
@@ -121,7 +120,7 @@ void LoggerCli::onMetricSkipped(const ResultEntry &e)
 
 // ── onTestSkippedAll ───────────────────────────────────────────────────────
 
-void LoggerCli::onTestSkippedAll(ResultStatus status, const std::string &reason)
+void LoggerText::onTestSkippedAll(ResultStatus status, const std::string &reason)
 {
     std::string tag;
     switch (status)
@@ -133,12 +132,12 @@ void LoggerCli::onTestSkippedAll(ResultStatus status, const std::string &reason)
     }
 
     writeLine(metricIndent, "[" + tag + "] " + reason);
-    std::cout.flush();
+    out.flush();
 }
 
 // ── onTestEnd ──────────────────────────────────────────────────────────────
 
-void LoggerCli::onTestEnd()
+void LoggerText::onTestEnd()
 {
     flushMetrics();
     indentLevel = propIndent;
@@ -146,28 +145,28 @@ void LoggerCli::onTestEnd()
 
 // ── onDeviceEnd ────────────────────────────────────────────────────────────
 
-void LoggerCli::onDeviceEnd()
+void LoggerText::onDeviceEnd()
 {
     // Ensure any remaining metrics are flushed (shouldn't happen if well-formed)
     if (!metricLines.empty())
         flushMetrics();
 
-    std::cout << "\n";
+    out << "\n";
     indentLevel = 0;
-    std::cout.flush();
+    out.flush();
 }
 
 // ── onBackendEnd ───────────────────────────────────────────────────────────
 
-void LoggerCli::onBackendEnd()
+void LoggerText::onBackendEnd()
 {
     indentLevel = 0;
-    std::cout.flush();
+    out.flush();
 }
 
 // ── flushMetrics ───────────────────────────────────────────────────────────
 
-void LoggerCli::flushMetrics()
+void LoggerText::flushMetrics()
 {
     if (metricLines.empty())
         return;
@@ -200,13 +199,13 @@ void LoggerCli::flushMetrics()
             ss << std::fixed << std::setprecision(2) << ml.value;
 
             // Print metric line without trailing newline (baseline delta may follow)
-            std::cout << indentStr(lineIndent) << padded << " : " << ss.str();
+            out << indentStr(lineIndent) << padded << " : " << ss.str();
 
             // Baseline delta on the same line (if enabled)
             if (compareEnabled)
                 printBaselineDelta(ml.metric, ml.value);
 
-            std::cout << "\n";
+            out << "\n";
         }
         else
         {
@@ -219,35 +218,35 @@ void LoggerCli::flushMetrics()
             default:                        tag = "unknown";     break;
             }
 
-            std::cout << indentStr(lineIndent) << padded << " : ["
-                      << tag << "] " << ml.reason << "\n";
+            out << indentStr(lineIndent) << padded << " : ["
+                << tag << "] " << ml.reason << "\n";
         }
     }
 
     metricLines.clear();
-    std::cout.flush();
+    out.flush();
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-std::string LoggerCli::indentStr(int level) const
+std::string LoggerText::indentStr(int level) const
 {
     if (level <= 0)
         return "";
     return std::string(static_cast<size_t>(level) * 2, ' ');
 }
 
-void LoggerCli::writeLine(int level, const std::string &text)
+void LoggerText::writeLine(int level, const std::string &text)
 {
-    std::cout << indentStr(level) << text << "\n";
+    out << indentStr(level) << text << "\n";
 }
 
-void LoggerCli::writeLine(const std::string &text)
+void LoggerText::writeLine(const std::string &text)
 {
     writeLine(indentLevel, text);
 }
 
-void LoggerCli::printBaselineDelta(const std::string &metric, float value)
+void LoggerText::printBaselineDelta(const std::string &metric, float value)
 {
     // Build key from current context
     std::string key = curBackend + "/" + curPlatform + "/" +
@@ -264,6 +263,6 @@ void LoggerCli::printBaselineDelta(const std::string &metric, float value)
     char  sign     = (delta >= 0.0f) ? '+' : '-';
     float absDelta = (delta < 0.0f)  ? -delta : delta;
 
-    std::cout << "  (was " << std::fixed << std::setprecision(2) << base
-              << ", " << sign << std::setprecision(1) << absDelta << "%)";
+    out << "  (was " << std::fixed << std::setprecision(2) << base
+        << ", " << sign << std::setprecision(1) << absDelta << "%)";
 }


### PR DESCRIPTION
Move logger_cli (TextLogger) to logger_text in src/common/ so it can be shared across CLI, Android, and iOS frontends. Update Android logger to inherit from the shared base. Update AGENTS.md files to reflect new layout.