### PR TITLE
Dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - 'results/**'
       - 'snap/**'
       - 'packaging/**'
+      - 'docs/**'
       - '**/*.md'
     branches: [master, main]
     tags: ["*"]
@@ -15,6 +16,7 @@ on:
       - 'results/**'
       - 'snap/**'
       - 'packaging/**'
+      - 'docs/**'
       - '**/*.md'
     branches: [master, main]
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,6 +277,8 @@ jobs:
   # (release depends on build-desktop only): no packaging, no artifact upload.
   # clang is purged so the run genuinely mirrors a GCC-only toolchain, and g++ is
   # also pinned via -DCMAKE_*_COMPILER so the build can't silently fall back.
+  # It also builds with -flto=auto, like the distro packages that first hit
+  # GCC's LTRANS-drops-the-TU-ISA-flags failure (see src/cpu/CMakeLists.txt).
   # ---------------------------------------------------------------------------
   build-linux-gcc:
     name: Linux x64 GCC
@@ -303,11 +305,13 @@ jobs:
           install_runtime: true
           cache: true
 
-      - name: Configure CMake & Build (GCC)
+      - name: Configure CMake & Build (GCC, LTO)
         run: |
           # GUI off: this job is a compiler smoke test, not a packaging job.
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DCLPEAK_ENABLE_GUI=OFF \
-            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_C_FLAGS=-flto=auto -DCMAKE_CXX_FLAGS=-flto=auto \
+            -DCMAKE_EXE_LINKER_FLAGS=-flto=auto
           cmake --build build --config Release -j4
 
       - name: Run

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # clpeak
 
-[![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=kr.clpeak)
+<a href="https://play.google.com/store/apps/details?id=kr.clpeak"><img alt="Get clpeak on Google Play" height="52" src="https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg"></a>
+<a href="https://snapcraft.io/clpeak"><img alt="Get clpeak from the Snap Store" height="52" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg"></a>
+
 [![Build](https://github.com/krrishnarraj/clpeak/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/krrishnarraj/clpeak/actions/workflows/build.yml)
 
 **clpeak &mdash; "Compute Latency PEAK".** A synthetic micro-benchmark for measuring the peak achievable compute performance of CPUs and GPUs. It exercises tight vector, MAD, and MMA kernels, together with vendor-optimized GEMM libraries, to expose peak hardware throughput.

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -189,6 +189,48 @@ td:first-child { font-family: var(--mono); }
 
 .rel-note { color: var(--dim); font-size: 14px; }
 
+/* Store links: the project's own wording and neutral glyphs rather than the
+   vendors' badge artwork, so the page stays self-contained (no third-party
+   requests) and matches the rest of the type. */
+.store-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.store-links a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--text);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 11px 16px;
+}
+.store-links a:hover { border-color: var(--accent); }
+
+.store-links svg {
+  flex: none;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  color: var(--dim);
+}
+.store-links a:hover svg { color: var(--accent); }
+
+.store-name { font: 600 14px/1.2 var(--mono); }
+.store-sub {
+  font: 11px/1.2 var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
 footer {
   border-top: 1px solid var(--line);
   padding-block: 24px 48px;

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,8 +98,6 @@ is listed, it is the desktop app — drag it to Applications.
 <p class="rel-note">
   Older versions are on the
   <a href="https://github.com/{{ site.repo }}/releases">releases page</a>.
-  clpeak is also packaged for
-  <a href="https://snapcraft.io/clpeak">Snap</a>, Flathub and Homebrew.
 </p>
 
 macOS builds are ad-hoc signed, so a downloaded copy starts out quarantined —
@@ -107,6 +105,34 @@ right-click the app and choose *Open* the first time, or clear the attribute:
 
 ```console
 xattr -dr com.apple.quarantine /Applications/clpeak-gui.app
+```
+
+### From a store
+
+<div class="store-links">
+  <a href="https://snapcraft.io/clpeak">
+    <svg viewBox="0 0 24 24" aria-hidden="true" width="22" height="22">
+      <path d="M12 2.6 21 7v10l-9 4.4L3 17V7z"/>
+      <path d="M3 7l9 4.4L21 7M12 11.4v10"/>
+    </svg>
+    <span class="store-name">Snap Store</span>
+    <span class="store-sub">Linux</span>
+  </a>
+  <a href="https://play.google.com/store/apps/details?id=kr.clpeak">
+    <svg viewBox="0 0 24 24" aria-hidden="true" width="22" height="22">
+      <rect x="6" y="2.5" width="12" height="19" rx="2.5"/>
+      <path d="M10.5 18.5h3"/>
+    </svg>
+    <span class="store-name">Google Play</span>
+    <span class="store-sub">Android</span>
+  </a>
+</div>
+
+On Linux the snap uses classic confinement, so it can reach the GPU drivers and
+device nodes the benchmarks need:
+
+```console
+sudo snap install clpeak --classic
 ```
 
 ## <a id="build"></a>Build from source

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,6 +68,11 @@ parts:
       fi
       mkdir -p "$CRAFT_PART_INSTALL/flutter"
       cp -a "$src/." "$CRAFT_PART_INSTALL/flutter/"
+      # The tarball carries its packer's uid/gid, which cp -a preserves.  The
+      # SDK is a git checkout and `flutter build` shells out to git against it,
+      # so a foreign owner trips git's "dubious ownership" guard and the build
+      # dies with error 128.  Hand the tree to whoever runs the build.
+      chown -R "$(id -u):$(id -g)" "$CRAFT_PART_INSTALL/flutter"
     prime:
       - -*
 

--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -69,6 +69,14 @@ local memory, DRAM ↔ global memory.
 - Optimization flags are scoped to `peak_cpu` only (see `CMakeLists.txt`).
 - `peak_common` is compiled with `ENABLE_CPU` too, because `options.cpp` and the
   help text gate the CPU flags on that macro.
+- **The ISA feature TUs never take part in LTO** (`clpeak_add_isa_tu` appends
+  `-fno-lto` / `/GL-`). A TU's `-m`/`-march` flags don't survive GCC's LTRANS
+  re-compile, so the assembler stops accepting its instructions: gcc 16.2 +
+  binutils 2.47 + Arch's `-flto=auto` failed the AMX-TF32 TU with
+  ``` `tmmultf32ps' is not supported on `x86_64' ``` while that same TU had just
+  assembled cleanly at compile time. LTO could also inline ISA code into the
+  baseline dispatcher (SIGILL on older CPUs). The GCC CI job builds with
+  `-flto=auto` to keep this covered.
 - **Build with clang, not GCC.** `NACC=24` assumes the compiler can schedule 24
   independent FMA chains; GCC ≤ 14 serialises them into one register and skips
   the k-loop unroll, roughly halving fp32/fp64. The root `CMakeLists.txt`

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -103,6 +103,21 @@ else()
 endif()
 target_compile_options(peak_cpu PRIVATE ${CLPEAK_CPU_OPT})
 
+# Keep the per-ISA feature TUs out of LTO (distros put -flto in the global
+# CXXFLAGS).  A TU's -m/-march flags don't survive GCC's LTRANS re-compile, so
+# the assembler no longer accepts its instructions -- gcc 16.2 + binutils 2.47
+# fail the AMX TU with "`tmmultf32ps' is not supported on `x86_64'" -- and LTO
+# could inline ISA code into the baseline dispatcher (SIGILL on older CPUs).
+set(CLPEAK_CPU_NO_LTO "")
+if(_clpeak_real_msvc)
+    set(CLPEAK_CPU_NO_LTO /GL-)
+else()
+    check_cxx_compiler_flag("${_clpeak_gnuflag}-fno-lto" _clpeak_f_no_lto)
+    if(_clpeak_f_no_lto)
+        set(CLPEAK_CPU_NO_LTO ${_clpeak_gnuflag}-fno-lto)
+    endif()
+endif()
+
 # Target arch.
 set(_clpeak_x86 OFF)
 set(_clpeak_arm OFF)
@@ -130,7 +145,8 @@ function(clpeak_add_isa_tu tag)
     target_include_directories(${_t} PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/../../include ${CMAKE_CURRENT_LIST_DIR})
     target_compile_definitions(${_t} PRIVATE ENABLE_CPU CLPEAK_ISA_TAG=${tag} ${CLPEAK_CPU_TU_DEFS})
-    target_compile_options(${_t} PRIVATE ${CLPEAK_CPU_OPT} ${ARGN})
+    target_compile_options(${_t} PRIVATE ${CLPEAK_CPU_OPT} ${CLPEAK_CPU_NO_LTO} ${ARGN})
+    set_target_properties(${_t} PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
     target_link_libraries(peak_cpu PRIVATE ${_t})
     target_compile_definitions(peak_cpu PRIVATE CLPEAK_TU_${tag}=1)
 endfunction()

--- a/src/ffi/CMakeLists.txt
+++ b/src/ffi/CMakeLists.txt
@@ -157,7 +157,7 @@ if(NOT CLPEAK_FFI_STANDALONE)
         # resource embedding, see linux/runner/my_application.cc).
         add_custom_target(clpeak-gui ALL
             DEPENDS clpeak_ffi
-            COMMAND ${FLUTTER_EXECUTABLE} build linux --release
+            COMMAND ${CMAKE_COMMAND} -E env DESTDIR= ${FLUTTER_EXECUTABLE} build linux --release
             COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLPEAK_GUI_OUT}"
             COMMAND ${CMAKE_COMMAND} -E copy_directory "${CLPEAK_APP_DIR}/build/linux/${_clpeak_flutter_arch}/release/bundle" "${CLPEAK_GUI_OUT}"
             COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:clpeak_ffi>" "${CLPEAK_GUI_OUT}/lib/"


### PR DESCRIPTION
- **[cpu] exclude ISA feature TUs from LTO** — ISA-specific kernel TUs now build with `-fno-lto` to prevent feature flags from being dropped during LTRANS re-compile, which caused assembler errors on architectures with strict ISA requirements
- **[CI] exclude docs** — Updated CI pipeline to skip documentation from triggering builds
- **[docs] update** — Enhanced documentation with CSS improvements and updated index content
- **[snap] fix permission** — Fixed snap package permission configuration
- **[ffi] use cmake env while launching flutter build** — Use proper CMake environment variables when building Flutter FFI