### PR TITLE
AMX tf32 fix

### DIFF
--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -44,7 +44,7 @@ local memory, DRAM ↔ global memory.
 | `kernels/base_compute.h` | fp32 / fp64 / int32 FMA chains, fp divide/sqrt, the scalar u64 integer divide, and the streaming read + vector write/copy kernels. Present in every TU |
 | `kernels/crypto_compute.h` | AES-128, SHA-256, SHA-512, CRC32-C. `opsPerIter` counts BYTES so `emitCompute()` lands in GB/s. SHA-512 is ARM-only: x86 SHA512 is *detected* but has no kernel, so that row is Unsupported there |
 | `kernels/lowp_compute.h` | fp16 FMA, bf16 dot, mixed-precision FMLAL, int8 dot, int16 dot, NEON fp8 dot, AVX10.2 bf16 vector FMA |
-| `kernels/matrix_compute.h` | x86 AMX (int8/bf16/fp16/tf32/fp8, sharing `amxConfig16x64()`) + ARM NEON SMMLA/BFMMLA |
+| `kernels/matrix_compute.h` | x86 AMX (int8/bf16/fp16/fp8, sharing `amxConfig16x64()`) + ARM NEON SMMLA/BFMMLA |
 | `kernels/string_compute.h` | memchr-style byte scan (incl. the historical SSE4.2 PCMPISTRI row) + Keiser-Lemire UTF-8 validation, over L1-resident buffers. `opsPerIter` counts BYTES |
 | `kernels/sve_compute.h` | SVE/SVE2 compute, bf16/i8mm matrix, fp8 dot, and the SVE `strscan`. Gated on `__ARM_FEATURE_SVE && !__ARM_FEATURE_SME`; owns the one `#include <arm_sve.h>` |
 | `kernels/sme_compute.h` | SME ZA outer products (fp32/fp64/bf16/fp16/int8) + streaming-SVE vector chains. Gated on `__ARM_FEATURE_SME`; owns the one `#include <arm_sme.h>` |
@@ -72,9 +72,8 @@ local memory, DRAM ↔ global memory.
 - **The ISA feature TUs never take part in LTO** (`clpeak_add_isa_tu` appends
   `-fno-lto` / `/GL-`). A TU's `-m`/`-march` flags don't survive GCC's LTRANS
   re-compile, so the assembler stops accepting its instructions: gcc 16.2 +
-  binutils 2.47 + Arch's `-flto=auto` failed the AMX-TF32 TU with
-  ``` `tmmultf32ps' is not supported on `x86_64' ``` while that same TU had just
-  assembled cleanly at compile time. LTO could also inline ISA code into the
+  binutils 2.47 + Arch's `-flto=auto` failed an AMX TU at link time (#193) while
+  that same TU had just assembled cleanly at compile time. LTO could also inline ISA code into the
   baseline dispatcher (SIGILL on older CPUs). The GCC CI job builds with
   `-flto=auto` to keep this covered.
 - **Build with clang, not GCC.** `NACC=24` assumes the compiler can schedule 24
@@ -105,7 +104,7 @@ TU tags (`cpu_tu_registry.h`):
 
 - **x86**: `generic` (SSE2 floor), `sse42`, `avx2`, `avxvnni`, `avxvnniint8`,
   `avxvnniint16`, `avx512`, `avx512vnni`, `avx512bf16`, `avx512fp16`,
-  `avx10bf16`, `amx`, `amxfp16`, `amxtf32`, `amxfp8`; crypto `aes`, `vaes`,
+  `avx10bf16`, `amx`, `amxfp16`, `amxfp8`; crypto `aes`, `vaes`,
   `sha` — CRC32-C has no TU of its own here, it rides in `sse42` (the CRC32
   instruction is part of SSE4.2).
 - **ARM**: `generic` (NEON floor, pinned to `apple-m1` on macOS), `fp16`,

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -153,13 +153,35 @@ endfunction()
 
 set(CLPEAK_CPU_TU_DEFS "")   # extra per-TU defs (e.g. CLPEAK_CORE_ONLY for MSVC)
 
-# A -march flag check alone doesn't prove the bleeding-edge ARM TUs can build:
-# SME additionally needs <arm_sme.h> + the ACLE streaming/ZA keyword attributes
-# (clang >= ~18), and FP8 needs the fpm_t/mfloat8 intrinsics (clang >= ~20).
-# These source checks compile the exact constructs the kernels use, so an older
-# toolchain fails them cleanly and simply skips the TU (-> Unsupported rows).
+# A -march/-m flag check alone doesn't prove a bleeding-edge TU can build, in
+# either direction:
+#   ARM   -- SME additionally needs <arm_sme.h> + the ACLE streaming/ZA keyword
+#            attributes (clang >= ~18), and FP8 needs the fpm_t/mfloat8
+#            intrinsics (clang >= ~20).
+#   x86   -- the driver can accept -mamx-tf32 while the *assembler* refuses the
+#            instruction it emits.  Intel deleted AMX-TF32 from the ISA before
+#            any silicon shipped; binutils dropped `tmmultf32ps' (gas 2.47)
+#            while GCC still advertises the flag, so gcc + new binutils dies with
+#            "`tmmultf32ps' is not supported on `x86_64'" (issues #193, #195).
+#            clang is unaffected -- its integrated assembler never asks gas.
+# These source checks compile the exact constructs the kernels use, so a
+# toolchain that can't build a TU fails them cleanly and simply skips it
+# (-> Unsupported rows) instead of breaking the build.  Compile+link only: the
+# probes never run, so no AMX XSTATE permission is involved.
+#
+# NOTES for anyone adding one:
+#  * Pass the flags as a list and let the helper join them.  CMAKE_REQUIRED_FLAGS
+#    is a space-separated *string*; assigning a ;-list to it silently drops
+#    everything after the first element, which turns the probe into an
+#    unconditional "fail" and disables the TU on every compiler.
+#  * The helpers append CLPEAK_CPU_NO_LTO so the probe sees what the TU sees:
+#    distros put -flto in CMAKE_CXX_FLAGS, the probe inherits it, and a -flto
+#    probe fails for the LTRANS reason in #193 -- skipping a TU that builds fine
+#    with the -fno-lto that clpeak_add_isa_tu() gives it.
 function(clpeak_check_sme outvar)
-    set(CMAKE_REQUIRED_FLAGS "${ARGN}")
+    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_sme.h>
         __arm_locally_streaming __arm_new(\"za\")
@@ -180,7 +202,9 @@ endfunction()
 # without defining the ACLE __ARM_FEATURE_SME_F64F64 macro, so the TU is gated
 # by a CMake-passed CLPEAK_SME_F64F64 define instead -- see sme_compute.h.)
 function(clpeak_check_sme_f64 outvar)
-    set(CMAKE_REQUIRED_FLAGS "${ARGN}")
+    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_sme.h>
         __arm_locally_streaming __arm_new(\"za\")
@@ -197,7 +221,9 @@ function(clpeak_check_sme_f64 outvar)
 endfunction()
 
 function(clpeak_check_neon_fp8 outvar)
-    set(CMAKE_REQUIRED_FLAGS "${ARGN}")
+    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_neon.h>
         static double f() {
@@ -213,7 +239,9 @@ function(clpeak_check_neon_fp8 outvar)
 endfunction()
 
 function(clpeak_check_sve_fp8 outvar)
-    set(CMAKE_REQUIRED_FLAGS "${ARGN}")
+    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_sve.h>
         static double f() {
@@ -225,6 +253,29 @@ function(clpeak_check_sve_fp8 outvar)
           return (double)svaddv_f32(pg, acc);
         }
         int main() { return (int)f(); }
+    " ${outvar})
+    set(${outvar} ${${outvar}} PARENT_SCOPE)
+endfunction()
+
+# The AMX dtype probes below emit the exact tile op each kernel issues, so a
+# toolchain whose assembler can't encode it skips the TU rather than failing the
+# build.  Unguarded on purpose: callers are already inside the x86 + 64-bit gate,
+# and a probe that compiled vacuously elsewhere would report a false positive.
+function(clpeak_check_amx_tile_op outvar op)
+    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
+    check_cxx_source_compiles("
+        #include <immintrin.h>
+        alignas(64) static char buf[16 * 64];
+        int main() {
+          _tile_loadd(4, buf, 64);
+          _tile_loadd(5, buf, 64);
+          _tile_zero(0);
+          ${op}(0, 4, 5);
+          _tile_stored(0, buf, 64);
+          return 0;
+        }
     " ${outvar})
     set(${outvar} ${${outvar}} PARENT_SCOPE)
 endfunction()
@@ -366,10 +417,11 @@ if(_clpeak_x86)
             clpeak_add_isa_tu(avx512fp16 ${_avx512_core} ${_clpeak_gnuflag}-mavx512fp16)
         endif()
         # AMX is a 64-bit-only ISA: GCC/clang accept the -mamx-* flags in
-        # 32-bit mode (so check_cxx_compiler_flag passes), but <immintrin.h>
-        # only declares the _tile_* intrinsics under #ifdef __x86_64__, so an
-        # i686 build would compile the AMX TU and then fail with "_tile_loadd
-        # was not declared".  Gate on a 64-bit target.  This is in the non-
+        # 32-bit mode, but <immintrin.h> only declares the _tile_* intrinsics
+        # under #ifdef __x86_64__, so an i686 build would compile the AMX TU and
+        # then fail with "_tile_loadd was not declared".  The tile-op probes
+        # below would catch that too; the explicit 64-bit gate keeps it obvious
+        # and saves three try_compiles.  This is in the non-
         # real-MSVC branch, so it covers Linux clang/gcc AND Windows clang-cl
         # (the -mamx-* flags route through ${_clpeak_gnuflag}'s /clang: prefix);
         # the AMX XSTATE grant is arch_prctl on Linux / EnableProcessOptional-
@@ -378,27 +430,31 @@ if(_clpeak_x86)
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
             set(_amx ${_avx512_core} ${_clpeak_gnuflag}-mamx-tile
                      ${_clpeak_gnuflag}-mamx-int8 ${_clpeak_gnuflag}-mamx-bf16)
-            check_cxx_compiler_flag("${_amx}" _clpeak_f_amx)
-            if(_clpeak_f_amx)
+            # int8 + bf16 share one TU, so both ops have to assemble for it to
+            # build -- probe each rather than trusting the flags.
+            clpeak_check_amx_tile_op(_clpeak_f_amx_i8   _tile_dpbssd   ${_amx})
+            clpeak_check_amx_tile_op(_clpeak_f_amx_bf16 _tile_dpbf16ps ${_amx})
+            if(_clpeak_f_amx_i8 AND _clpeak_f_amx_bf16)
                 clpeak_add_isa_tu(amx ${_amx})
             endif()
             # Newer AMX dtypes as their own TUs (each is a separate CPUID
             # feature + a newer compiler; runtime-gated so an older CPU never
             # issues them).  amx-tile is the common base; the -mamx-fp16 /
-            # -mamx-tf32 / -mamx-fp8 flags need clang>=~18/20 (older toolchains
-            # fail the check and simply skip the TU -> Unsupported row).
+            # -mamx-tf32 / -mamx-fp8 flags need clang>=~18/20, and the tf32 op
+            # is gone from current binutils -- either way the probe fails and
+            # the TU is simply skipped (-> Unsupported row).
             set(_amxfp16 ${_clpeak_gnuflag}-mamx-tile ${_clpeak_gnuflag}-mamx-fp16)
-            check_cxx_compiler_flag("${_amxfp16}" _clpeak_f_amxfp16)
+            clpeak_check_amx_tile_op(_clpeak_f_amxfp16 _tile_dpfp16ps ${_amxfp16})
             if(_clpeak_f_amxfp16)
                 clpeak_add_isa_tu(amxfp16 ${_amxfp16})
             endif()
             set(_amxtf32 ${_clpeak_gnuflag}-mamx-tile ${_clpeak_gnuflag}-mamx-tf32)
-            check_cxx_compiler_flag("${_amxtf32}" _clpeak_f_amxtf32)
+            clpeak_check_amx_tile_op(_clpeak_f_amxtf32 _tile_mmultf32ps ${_amxtf32})
             if(_clpeak_f_amxtf32)
                 clpeak_add_isa_tu(amxtf32 ${_amxtf32})
             endif()
             set(_amxfp8 ${_clpeak_gnuflag}-mamx-tile ${_clpeak_gnuflag}-mamx-fp8)
-            check_cxx_compiler_flag("${_amxfp8}" _clpeak_f_amxfp8)
+            clpeak_check_amx_tile_op(_clpeak_f_amxfp8 _tile_dphf8ps ${_amxfp8})
             if(_clpeak_f_amxfp8)
                 clpeak_add_isa_tu(amxfp8 ${_amxfp8})
             endif()

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -105,9 +105,9 @@ target_compile_options(peak_cpu PRIVATE ${CLPEAK_CPU_OPT})
 
 # Keep the per-ISA feature TUs out of LTO (distros put -flto in the global
 # CXXFLAGS).  A TU's -m/-march flags don't survive GCC's LTRANS re-compile, so
-# the assembler no longer accepts its instructions -- gcc 16.2 + binutils 2.47
-# fail the AMX TU with "`tmmultf32ps' is not supported on `x86_64'" -- and LTO
-# could inline ISA code into the baseline dispatcher (SIGILL on older CPUs).
+# the assembler stops accepting its instructions at link time even though the TU
+# assembled cleanly (#193) -- and LTO could inline ISA code into the baseline
+# dispatcher (SIGILL on older CPUs).
 set(CLPEAK_CPU_NO_LTO "")
 if(_clpeak_real_msvc)
     set(CLPEAK_CPU_NO_LTO /GL-)
@@ -153,34 +153,23 @@ endfunction()
 
 set(CLPEAK_CPU_TU_DEFS "")   # extra per-TU defs (e.g. CLPEAK_CORE_ONLY for MSVC)
 
-# A -march/-m flag check alone doesn't prove a bleeding-edge TU can build, in
-# either direction:
-#   ARM   -- SME additionally needs <arm_sme.h> + the ACLE streaming/ZA keyword
-#            attributes (clang >= ~18), and FP8 needs the fpm_t/mfloat8
-#            intrinsics (clang >= ~20).
-#   x86   -- the driver can accept -mamx-tf32 while the *assembler* refuses the
-#            instruction it emits.  Intel deleted AMX-TF32 from the ISA before
-#            any silicon shipped; binutils dropped `tmmultf32ps' (gas 2.47)
-#            while GCC still advertises the flag, so gcc + new binutils dies with
-#            "`tmmultf32ps' is not supported on `x86_64'" (issues #193, #195).
-#            clang is unaffected -- its integrated assembler never asks gas.
-# These source checks compile the exact constructs the kernels use, so a
-# toolchain that can't build a TU fails them cleanly and simply skips it
-# (-> Unsupported rows) instead of breaking the build.  Compile+link only: the
-# probes never run, so no AMX XSTATE permission is involved.
+# A -march/-m flag check alone doesn't prove a bleeding-edge TU can build: SME
+# also needs <arm_sme.h> + the ACLE streaming/ZA keywords (clang >= ~18), FP8 the
+# fpm_t/mfloat8 intrinsics (clang >= ~20), and on x86 the driver can accept an
+# -mamx-* flag whose instruction the *assembler* then refuses -- that is how
+# AMX-TF32 broke gcc + binutils 2.47 builds (#193, #195) before Intel deleted the
+# ISA.  These probes compile the exact constructs the kernels use, so such a
+# toolchain skips the TU (-> Unsupported rows) instead of failing the build.
+# Compile+link only: they never run, so no AMX XSTATE permission is involved.
 #
-# NOTES for anyone adding one:
-#  * Pass the flags as a list and let the helper join them.  CMAKE_REQUIRED_FLAGS
-#    is a space-separated *string*; assigning a ;-list to it silently drops
-#    everything after the first element, which turns the probe into an
-#    unconditional "fail" and disables the TU on every compiler.
-#  * The helpers append CLPEAK_CPU_NO_LTO so the probe sees what the TU sees:
-#    distros put -flto in CMAKE_CXX_FLAGS, the probe inherits it, and a -flto
-#    probe fails for the LTRANS reason in #193 -- skipping a TU that builds fine
-#    with the -fno-lto that clpeak_add_isa_tu() gives it.
+# When adding one, mind what goes into CMAKE_REQUIRED_FLAGS.  It is a space-
+# separated *string*: assigning a ;-list drops everything after the first
+# element and the probe then fails on every compiler.  The helpers also append
+# CLPEAK_CPU_NO_LTO, so a distro -flto in CMAKE_CXX_FLAGS can't fail a probe for
+# the LTRANS reason in #193 that the TU's own -fno-lto build doesn't have.
 function(clpeak_check_sme outvar)
-    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
-    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    list(JOIN ARGN " " _reqflags)               # string, NOT a ;-list -- see above
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto)
     set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_sme.h>
@@ -202,8 +191,8 @@ endfunction()
 # without defining the ACLE __ARM_FEATURE_SME_F64F64 macro, so the TU is gated
 # by a CMake-passed CLPEAK_SME_F64F64 define instead -- see sme_compute.h.)
 function(clpeak_check_sme_f64 outvar)
-    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
-    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    list(JOIN ARGN " " _reqflags)               # string, NOT a ;-list -- see above
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto)
     set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_sme.h>
@@ -221,8 +210,8 @@ function(clpeak_check_sme_f64 outvar)
 endfunction()
 
 function(clpeak_check_neon_fp8 outvar)
-    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
-    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    list(JOIN ARGN " " _reqflags)               # string, NOT a ;-list -- see above
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto)
     set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_neon.h>
@@ -239,8 +228,8 @@ function(clpeak_check_neon_fp8 outvar)
 endfunction()
 
 function(clpeak_check_sve_fp8 outvar)
-    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
-    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    list(JOIN ARGN " " _reqflags)               # string, NOT a ;-list -- see above
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto)
     set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <arm_sve.h>
@@ -257,13 +246,12 @@ function(clpeak_check_sve_fp8 outvar)
     set(${outvar} ${${outvar}} PARENT_SCOPE)
 endfunction()
 
-# The AMX dtype probes below emit the exact tile op each kernel issues, so a
-# toolchain whose assembler can't encode it skips the TU rather than failing the
-# build.  Unguarded on purpose: callers are already inside the x86 + 64-bit gate,
-# and a probe that compiled vacuously elsewhere would report a false positive.
+# Emits the exact tile op the kernel issues.  Deliberately unguarded by any
+# __x86_64__ #if: callers are already inside the x86 + 64-bit gate, and a probe
+# that compiled vacuously elsewhere would report a false positive.
 function(clpeak_check_amx_tile_op outvar op)
-    list(JOIN ARGN " " _reqflags)              # string, NOT a ;-list (see above)
-    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto) # probe the TU as it is really built
+    list(JOIN ARGN " " _reqflags)               # string, NOT a ;-list -- see above
+    list(JOIN CLPEAK_CPU_NO_LTO " " _reqnolto)
     set(CMAKE_REQUIRED_FLAGS "${_reqflags} ${_reqnolto}")
     check_cxx_source_compiles("
         #include <immintrin.h>
@@ -419,9 +407,8 @@ if(_clpeak_x86)
         # AMX is a 64-bit-only ISA: GCC/clang accept the -mamx-* flags in
         # 32-bit mode, but <immintrin.h> only declares the _tile_* intrinsics
         # under #ifdef __x86_64__, so an i686 build would compile the AMX TU and
-        # then fail with "_tile_loadd was not declared".  The tile-op probes
-        # below would catch that too; the explicit 64-bit gate keeps it obvious
-        # and saves three try_compiles.  This is in the non-
+        # then fail with "_tile_loadd was not declared".  The probes below would
+        # catch that too; the explicit gate keeps it obvious.  This is in the non-
         # real-MSVC branch, so it covers Linux clang/gcc AND Windows clang-cl
         # (the -mamx-* flags route through ${_clpeak_gnuflag}'s /clang: prefix);
         # the AMX XSTATE grant is arch_prctl on Linux / EnableProcessOptional-
@@ -439,19 +426,11 @@ if(_clpeak_x86)
             endif()
             # Newer AMX dtypes as their own TUs (each is a separate CPUID
             # feature + a newer compiler; runtime-gated so an older CPU never
-            # issues them).  amx-tile is the common base; the -mamx-fp16 /
-            # -mamx-tf32 / -mamx-fp8 flags need clang>=~18/20, and the tf32 op
-            # is gone from current binutils -- either way the probe fails and
-            # the TU is simply skipped (-> Unsupported row).
+            # issues them).  amx-tile is the common base.
             set(_amxfp16 ${_clpeak_gnuflag}-mamx-tile ${_clpeak_gnuflag}-mamx-fp16)
             clpeak_check_amx_tile_op(_clpeak_f_amxfp16 _tile_dpfp16ps ${_amxfp16})
             if(_clpeak_f_amxfp16)
                 clpeak_add_isa_tu(amxfp16 ${_amxfp16})
-            endif()
-            set(_amxtf32 ${_clpeak_gnuflag}-mamx-tile ${_clpeak_gnuflag}-mamx-tf32)
-            clpeak_check_amx_tile_op(_clpeak_f_amxtf32 _tile_mmultf32ps ${_amxtf32})
-            if(_clpeak_f_amxtf32)
-                clpeak_add_isa_tu(amxtf32 ${_amxtf32})
             endif()
             set(_amxfp8 ${_clpeak_gnuflag}-mamx-tile ${_clpeak_gnuflag}-mamx-fp8)
             clpeak_check_amx_tile_op(_clpeak_f_amxfp8 _tile_dphf8ps ${_amxfp8})

--- a/src/cpu/cpu_device.cpp
+++ b/src/cpu/cpu_device.cpp
@@ -388,7 +388,7 @@ static void detectIsa(cpu_device_info_t &info)
   info.hasBF16    = f.bf16 || f.avx512bf16 || f.svebf16 || f.avx10_2_512;
   info.hasInt8DP  = f.dotprod || f.avx512vnni || f.avxvnni || f.avxvnniint8 || f.sve;
   info.hasAVXVNNI = f.avxvnni || f.avxvnniint8;
-  info.hasAMX     = f.amx_int8 || f.amx_bf16 || f.amx_fp16 || f.amx_tf32 || f.amx_fp8;
+  info.hasAMX     = f.amx_int8 || f.amx_bf16 || f.amx_fp16 || f.amx_fp8;
   info.hasSVE     = f.sve;
   info.hasSVE2    = f.sve2;
   info.sveVLBytes = clpeak_cpu::sveVLBytes();

--- a/src/cpu/cpu_dispatch.cpp
+++ b/src/cpu/cpu_dispatch.cpp
@@ -102,7 +102,7 @@ static CpuFeatures detect()
     f.amx_fp8 = (ecx >> 3) & 1;
     // Leaf 7 sub-leaf 1 (bit positions per Intel ISA ref / klauspost-cpuid):
     //   EAX[4]=AVX-VNNI, EAX[5]=AVX512-BF16, EAX[21]=AMX-FP16;
-    //   EDX[4]=AVX-VNNI-INT8, EDX[7]=AMX-TF32, EDX[19]=AVX10.
+    //   EDX[4]=AVX-VNNI-INT8, EDX[19]=AVX10.
     // AVX-VNNI / AVX-VNNI-INT8 are 256-bit VEX (OS AVX state only, no AVX-512).
     {
       uint32_t r1[4];
@@ -112,7 +112,6 @@ static CpuFeatures detect()
       f.avxvnniint8  = ((edx1 >> 4) & 1) && osAvx && avxcpu;
       f.avxvnniint16 = ((edx1 >> 10) & 1) && osAvx && avxcpu;  // EDX[10] (Intel ISA ref / klauspost-cpuid)
       f.amx_fp16    = (eax1 >> 21) & 1;
-      f.amx_tf32    = (edx1 >> 7) & 1;
       f.avx10       = (edx1 >> 19) & 1;
       // Leaf 7 sub-leaf 1 EAX[0] = SHA512 (EVEX; Arrow/Lunar Lake).  Detection
       // only today: no x86 SHA-512 kernel yet, so nothing consumes it -- wired
@@ -284,7 +283,6 @@ static void merge(CpuKernelTable &d, const CpuKernelTable *s)
   if (s->mat_int8.fn) d.mat_int8 = s->mat_int8;
   if (s->mat_fp.fn)   d.mat_fp = s->mat_fp;
   if (s->mat_fp16.fn) d.mat_fp16 = s->mat_fp16;
-  if (s->mat_tf32.fn) d.mat_tf32 = s->mat_tf32;
   if (s->mat_fp8.fn)  d.mat_fp8 = s->mat_fp8;
   if (s->bf16fma.fn)  d.bf16fma = s->bf16fma;
   if (s->int16dp.fn)  d.int16dp = s->int16dp;
@@ -384,9 +382,6 @@ const CpuKernelTable &kernels()
 #endif
 #if CLPEAK_TU_amxfp16
     if (f.amx_tile && f.amx_fp16 && amxPermOk()) merge(t, clpeak_table_amxfp16());
-#endif
-#if CLPEAK_TU_amxtf32
-    if (f.amx_tile && f.amx_tf32 && amxPermOk()) merge(t, clpeak_table_amxtf32());
 #endif
 #if CLPEAK_TU_amxfp8
     if (f.amx_tile && f.amx_fp8 && amxPermOk()) merge(t, clpeak_table_amxfp8());
@@ -597,10 +592,6 @@ const CpuKernelMenu &kernelMenu()
 #if CLPEAK_TU_amxfp16
     if (f.amx_tile && f.amx_fp16 && amxPermOk())
       add(m.mat_fp16, clpeak_table_amxfp16()->mat_fp16, "AMX FP16");
-#endif
-#if CLPEAK_TU_amxtf32
-    if (f.amx_tile && f.amx_tf32 && amxPermOk())
-      add(m.mat_tf32, clpeak_table_amxtf32()->mat_tf32, "AMX TF32");
 #endif
 #if CLPEAK_TU_amxfp8
     if (f.amx_tile && f.amx_fp8 && amxPermOk())

--- a/src/cpu/cpu_kernels.h
+++ b/src/cpu/cpu_kernels.h
@@ -29,7 +29,7 @@ struct CpuFeatures {
   bool avxvnniint16 = false; // 256-bit AVX-VNNI-INT16 (mixed-sign int16 dot; Diamond Rapids, Nova Lake)
   bool avx10 = false, avx10_2_512 = false;  // AVX10.2 512-bit (Diamond Rapids): native bf16 FMA
   bool amx_tile = false, amx_int8 = false, amx_bf16 = false;
-  bool amx_fp16 = false, amx_tf32 = false, amx_fp8 = false;  // Granite/Diamond Rapids AMX dtypes
+  bool amx_fp16 = false, amx_fp8 = false;  // Granite/Diamond Rapids AMX dtypes
   // ARM
   bool neon = false, fp16 = false, fp16fml = false, dotprod = false, bf16 = false, i8mm = false;
   // ARM SVE.  The compute kernels are vector-length-agnostic (one binary runs
@@ -78,9 +78,9 @@ struct ChainVariant {
 // One feature TU's offered kernels (null entries = not provided by that ISA).
 struct CpuKernelTable {
   ChainVariant fp32, fp64, int32, fp16, bf16, mp, int8dp, mat_int8, mat_fp;
-  // Newer x86 matrix/vector dtypes: AMX fp16 (Granite Rapids), AMX tf32 / AMX fp8
-  // (Diamond Rapids), and native bf16 vector FMA (AVX10.2, full-rate, not a dot).
-  ChainVariant mat_fp16, mat_tf32, mat_fp8, bf16fma;
+  // Newer x86 matrix/vector dtypes: AMX fp16 (Granite Rapids), AMX fp8 (Diamond
+  // Rapids), and native bf16 vector FMA (AVX10.2, full-rate, not a dot).
+  ChainVariant mat_fp16, mat_fp8, bf16fma;
   // int16 dot (x86 VPDPWSSD / VPDPWSUD) and ARM fp8 dot (FEAT_FP8DOT4 FDOT).
   ChainVariant int16dp, fp8dp;
   // ARM SME: fp32/fp64 ZA outer products (no x86 engine has these dtypes) and
@@ -128,7 +128,7 @@ struct IsaVariant {
 // compare instruction sets, rather than only the widest one (see kernels()).
 struct CpuKernelMenu {
   std::vector<IsaVariant> fp32, fp64, int32, fp16, bf16, mp, int8dp, mat_int8, mat_fp;
-  std::vector<IsaVariant> mat_fp16, mat_tf32, mat_fp8, bf16fma;
+  std::vector<IsaVariant> mat_fp16, mat_fp8, bf16fma;
   std::vector<IsaVariant> int16dp, fp8dp, mat_fp32, mat_fp64;
   std::vector<IsaVariant> aes, sha256, sha512, crc32c;
   // String tests: the PCMPISTRI kernel rides in the strscan menu as its own

--- a/src/cpu/cpu_kernels_impl.h
+++ b/src/cpu/cpu_kernels_impl.h
@@ -10,7 +10,7 @@
 //   kernels/base_compute.h    fp32 / fp64 / int32 chains + streaming read (all TUs)
 //   kernels/lowp_compute.h    fp16 / bf16-dot / mixed-precision / int8-dot / int16-dot
 //                             / fp8-dot (NEON) / bf16-FMA
-//   kernels/matrix_compute.h  AMX (int8/bf16/fp16/tf32/fp8) + NEON SMMLA/BFMMLA
+//   kernels/matrix_compute.h  AMX (int8/bf16/fp16/fp8) + NEON SMMLA/BFMMLA
 //   kernels/crypto_compute.h  AES / SHA-256 / SHA-512 / CRC32-C
 //   kernels/string_compute.h  memchr-style byte scan + UTF-8 validation
 //   kernels/sve_compute.h     ARM SVE compute + SVE bf16/i8mm matrix + SVE fp8 dot
@@ -90,9 +90,6 @@ static const CpuKernelTable *tuTable()
 #endif
 #ifdef CPU_MAT_FP16_KERNEL
     t.mat_fp16 = {runMatFp16Chain, (double)INNER * MAT_FP16_OPS_PER_K};
-#endif
-#ifdef CPU_MAT_TF32_KERNEL
-    t.mat_tf32 = {runMatTf32Chain, (double)INNER * MAT_TF32_OPS_PER_K};
 #endif
 #ifdef CPU_MAT_FP8_KERNEL
     t.mat_fp8 = {runMatFp8Chain, (double)INNER * MAT_FP8_OPS_PER_K};

--- a/src/cpu/cpu_matrix.cpp
+++ b/src/cpu/cpu_matrix.cpp
@@ -35,16 +35,9 @@ int CpuPeak::runCpuMatrix(benchmark_config_t &cfg, Category category)
                  "no CPU fp16 matrix engine (AMX-FP16 / SME) on this CPU", cfg);
 #endif
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-    // tf32/fp8 matrix are AMX-only (Diamond Rapids) -- x86 exclusive, so only
-    // emit them (incl. the Unsupported row) on an x86 build.  On ARM there is
-    // no tile instruction for these dtypes today, so the rows would be noise.
-    emitVariants(*this, {"cpu_matrix_tf32", "CPU matrix engine (tf32)", "gflops",
-                         Category::Unknown,
-                         "The same built-in matrix engine on tf32, a trimmed-down "
-                         "stand-in for 32-bit float that trades accuracy for speed "
-                         "(Intel AMX-TF32)."},
-                 "matrix_tf32", kernelMenu().mat_tf32,
-                 "no CPU tf32 matrix engine (AMX-TF32) on this CPU", cfg);
+    // fp8 matrix is AMX-only (Diamond Rapids) -- x86 exclusive, so only emit it
+    // (incl. the Unsupported row) on an x86 build.  On ARM there is no tile
+    // instruction for this dtype today, so the row would be noise.
     emitVariants(*this, {"cpu_matrix_fp8", "CPU matrix engine (fp8)", "gflops",
                          Category::Unknown,
                          "The same built-in matrix engine on 8-bit float inputs, the "

--- a/src/cpu/cpu_tu_registry.h
+++ b/src/cpu/cpu_tu_registry.h
@@ -35,7 +35,6 @@
   CLPEAK_TU(avx10bf16)    /* AVX10.2-512 native bf16 vector FMA */          \
   CLPEAK_TU(amx)          /* AMX int8 + bf16 */                             \
   CLPEAK_TU(amxfp16)                                                        \
-  CLPEAK_TU(amxtf32)                                                        \
   CLPEAK_TU(amxfp8)                                                         \
   /* Crypto TUs: same tag on both arches (only one arch branch builds it) */ \
   CLPEAK_TU(aes)          /* x86 AES-NI / ARM FEAT_AES */                   \

--- a/src/cpu/kernels/matrix_compute.h
+++ b/src/cpu/kernels/matrix_compute.h
@@ -5,7 +5,7 @@
 
 // ===========================================================================
 // CPU matrix-engine kernels (the tensor-core analog): Intel AMX tile ops on x86
-// (int8 / bf16 / fp16 / tf32 / fp8) and the ARM NEON matrix instructions SMMLA
+// (int8 / bf16 / fp16 / fp8) and the ARM NEON matrix instructions SMMLA
 // (int8) + BFMMLA (bf16).  ops are PER-k; the table builder multiplies by INNER.
 // Feature-gated + CLPEAK_CORE_ONLY-excluded like the other advanced kernels.  To
 // add a new AMX dtype: reuse amxConfig16x64(), add a #if block + a
@@ -136,13 +136,13 @@ static double runMatFpChain(uint64_t outer)
 }
 #endif
 
-// ---- Newer x86 AMX matrix dtypes: fp16 / tf32 / fp8 ------------------------
+// ---- Newer x86 AMX matrix dtypes: fp16 / fp8 -------------------------------
 // Same 4-accumulator-tile config as the int8/bf16 AMX kernels (opaque tiles, so
 // the accumulate loop can't be scalar-evolved; inputs zero => data-independent
 // throughput; output tiles thread_local so every MT worker gets its own).  The
 // TILECFG is the canonical palette-1 / 16-row / 64-colsb layout for all of them;
 // only the element width (hence K per tile) and the DP intrinsic differ.
-#if (defined(__AMX_FP16__) || defined(__AMX_TF32__) || defined(__AMX_FP8__)) && \
+#if (defined(__AMX_FP16__) || defined(__AMX_FP8__)) && \
     (defined(__x86_64__) || defined(_M_X64))
 static void amxConfig16x64()
 {
@@ -174,31 +174,6 @@ static double runMatFp16Chain(uint64_t outer)
   _tile_stored(1, g_amxCf16, 64); sink += g_amxCf16[0];
   _tile_stored(2, g_amxCf16, 64); sink += g_amxCf16[0];
   _tile_stored(3, g_amxCf16, 64); sink += g_amxCf16[0];
-  return sink;
-}
-#endif
-
-#if defined(__AMX_TF32__) && (defined(__x86_64__) || defined(_M_X64))
-#define CPU_MAT_TF32_KERNEL 1
-static constexpr double MAT_TF32_OPS_PER_K = 4.0 * 16 * 16 * 16 * 2;  // K=16 tf32(fp32-stored)/row
-static thread_local bool g_amxTf32Cfg = false;
-alignas(64) static float g_amxAt32[16 * 16];
-alignas(64) static float g_amxBt32[16 * 16];
-alignas(64) static thread_local float g_amxCt32[16 * 16];
-static double runMatTf32Chain(uint64_t outer)
-{
-  if (!g_amxTf32Cfg) { amxConfig16x64(); g_amxTf32Cfg = true; }
-  _tile_loadd(4, g_amxAt32, 64);
-  _tile_loadd(5, g_amxBt32, 64);
-  _tile_zero(0); _tile_zero(1); _tile_zero(2); _tile_zero(3);
-  for (uint64_t o = 0; o < outer; o++)
-    for (int k = 0; k < INNER; k++)
-    { _tile_mmultf32ps(0, 4, 5); _tile_mmultf32ps(1, 4, 5); _tile_mmultf32ps(2, 4, 5); _tile_mmultf32ps(3, 4, 5); }
-  double sink = 0.0;
-  _tile_stored(0, g_amxCt32, 64); sink += g_amxCt32[0];
-  _tile_stored(1, g_amxCt32, 64); sink += g_amxCt32[0];
-  _tile_stored(2, g_amxCt32, 64); sink += g_amxCt32[0];
-  _tile_stored(3, g_amxCt32, 64); sink += g_amxCt32[0];
   return sink;
 }
 #endif


### PR DESCRIPTION
- Fix AMX feature-TU detection to probe the actual tile instruction (`check_cxx_source_compiles`) instead of trusting `check_cxx_compiler_flag`, which only proves the driver accepts `-mamx-*` and not that the assembler can encode what gets emitted. Fixes gcc + binutils 2.47 builds that die with `` `tmmultf32ps' is not supported on `x86_64' `` (#193, #195). clang was never affected — its integrated assembler never calls out to gas.
- Remove the AMX-TF32 matrix test (TU, kernel, CPUID bit, table/menu slots, row). Intel deleted AMX-TF32 from the ISA before any silicon shipped, so the runtime gate could never fire on real hardware — the row was a permanent Unsupported. No observable change on any existing CPU.