### PR TITLE
cmake: let the builder supply the version with CLPEAK_VERSION_OVERRIDE

### DIFF
--- a/src/common/cmake/version.cmake
+++ b/src/common/cmake/version.cmake
@@ -4,6 +4,13 @@
 # binary): a hardcoded number there is worse than no number, because it silently
 # stamps every such build with a version it isn't.
 #
+# A builder that knows the version for certain can pass it in instead, with
+# -DCLPEAK_VERSION_OVERRIDE=<version>.  This is the distribution-packaging case:
+# the source is the release tarball of exactly that tag, so the number is a fact
+# the builder holds and git does not.  It is not the stale in-tree fallback this
+# file used to carry -- nothing in the repository supplies a value, so a build
+# that does not set it still reports "unknown".
+#
 # Derived once, at configure time, never during the build: the GUI build rewrites
 # tracked files (Flutter owns pubspec.lock, analysis_options.yaml and the
 # generated plugin registrants), which anything re-deriving later reads as
@@ -22,22 +29,29 @@ if(NOT DEFINED CLPEAK_GIT_ROOT)
     get_filename_component(CLPEAK_GIT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
 endif()
 
-find_package(Git QUIET)
-
 set(CLPEAK_VERSION_STR "${CLPEAK_VERSION_UNKNOWN}")
-if(GIT_FOUND AND EXISTS "${CLPEAK_GIT_ROOT}/.git")
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
-        WORKING_DIRECTORY ${CLPEAK_GIT_ROOT}
-        OUTPUT_VARIABLE _git_version
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        RESULT_VARIABLE _git_result
-    )
-    if(_git_result EQUAL 0 AND NOT _git_version STREQUAL "")
-        # Strip optional leading 'v' (tags mix v1.0 and 1.1.7)
-        string(REGEX REPLACE "^v" "" _git_version "${_git_version}")
-        set(CLPEAK_VERSION_STR "${_git_version}")
+
+if(CLPEAK_VERSION_OVERRIDE)
+    # Strip optional leading 'v' as the git path does, so both spellings of a
+    # tag give the same string.
+    string(REGEX REPLACE "^v" "" CLPEAK_VERSION_STR "${CLPEAK_VERSION_OVERRIDE}")
+else()
+    find_package(Git QUIET)
+
+    if(GIT_FOUND AND EXISTS "${CLPEAK_GIT_ROOT}/.git")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+            WORKING_DIRECTORY ${CLPEAK_GIT_ROOT}
+            OUTPUT_VARIABLE _git_version
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+            RESULT_VARIABLE _git_result
+        )
+        if(_git_result EQUAL 0 AND NOT _git_version STREQUAL "")
+            # Strip optional leading 'v' (tags mix v1.0 and 1.1.7)
+            string(REGEX REPLACE "^v" "" _git_version "${_git_version}")
+            set(CLPEAK_VERSION_STR "${_git_version}")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
2.1.3 dropped the hardcoded in-tree fallback, so a build without git reports `unknown`. That is the right answer for an arbitrary snapshot, but distribution packages build the release tarball of exactly one tag — the version is a fact the builder holds and git does not.

`unknown` does not only show up in `--version`: `result_store.cpp` writes it into the `clpeak_version` field of every JSON, XML and CSV export, which is what makes a pasted result attributable to a release.

The existing escape hatch is to build from a git URL instead of the tarball — Arch's PKGBUILD and the Homebrew formula both do, and 2.1.3's release notes mention updating the formula's comment for exactly this reason. That trades a mirrored, checksummed tarball for a network clone at build time, which most distribution build services cannot do.

This adds `-DCLPEAK_VERSION_OVERRIDE=<version>`. It cannot go stale the way the old fallback did: nothing in the tree supplies a value, so a build that does not pass it still reports `unknown` and the git path is unchanged. A leading `v` is stripped as on the git path, so both tag spellings agree.

Checked all three branches with `cmake -P` against `version.cmake`: override `2.1.3` -> `2.1.3`, override `v2.1.3` -> `2.1.3`, no override in a git tree -> `2.1.3-dirty` (git-describe, as before).

Filed while packaging 2.1.3 for openSUSE, where it replaces a `sed` on the old `CLPEAK_VERSION_FALLBACK` line that silently became a no-op in this release.
