### PR TITLE
Merge 2.1.x to master

### DIFF
--- a/results/AMD/Ryzen_Threadripper_PRO_3955WX_16_Cores.xml
+++ b/results/AMD/Ryzen_Threadripper_PRO_3955WX_16_Cores.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<clpeak format_version="2" clpeak_version="2.1.2-64-g71043e1" os="Linux x64">
+<clpeak format_version="2" clpeak_version="2.1.2-69-g940fa86" os="Linux x64">
   <run backend="oneAPI" platform="oneAPI" device="AMD Ryzen Threadripper PRO 3955WX 16-Cores     " driver="2026.21.7.0.24_160000">
     <prop name="Vendor" value="Intel(R) Corporation"/>
     <prop name="Type" value="CPU"/>
@@ -9,31 +9,31 @@
     <prop name="VRAM" value="188708 MB"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">1568.1809</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">786.4479</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">1554.8450</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">1916.7806</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">1292.5992</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">1542.2648</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">782.3029</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">1543.4896</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">1905.3359</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">1286.2728</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on.">
-        <metric name="half" info="One value per work-item at a time -- the plain, unvectorised case.">252.0913</metric>
-        <metric name="half2" info="Two values per work-item at a time, as one 2-wide vector.">82.7660</metric>
-        <metric name="half4" info="Four values per work-item at a time, as one 4-wide vector.">183.8152</metric>
-        <metric name="half8" info="Eight values per work-item at a time, as one 8-wide vector.">289.8133</metric>
-        <metric name="half16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">212.4737</metric>
+        <metric name="half" info="One value per work-item at a time -- the plain, unvectorised case.">250.7599</metric>
+        <metric name="half2" info="Two values per work-item at a time, as one 2-wide vector.">82.5451</metric>
+        <metric name="half4" info="Four values per work-item at a time, as one 4-wide vector.">182.8638</metric>
+        <metric name="half8" info="Eight values per work-item at a time, as one 8-wide vector.">288.0320</metric>
+        <metric name="half16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">211.5668</metric>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts run these far slower than 32-bit; the datacenter parts do not.">
-        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">926.5533</metric>
-        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">869.2539</metric>
-        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">844.8428</metric>
-        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">465.4196</metric>
-        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">307.0663</metric>
+        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">925.9873</metric>
+        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">869.0607</metric>
+        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">839.5451</metric>
+        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">464.2828</metric>
+        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">307.1185</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses. This is the general compute units, not the matrix engine.">
-        <metric name="mp">953.0256</metric>
+        <metric name="mp">1464.4972</metric>
       </test>
       <test name="bfloat16_compute" display="BF16 compute bf16xbf16+fp32" unit="gflops" description="Peak speed on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float. Integrated graphics without bf16 hardware emulate it, and the rate drops accordingly.">
-        <metric name="bf16">1357.4512</metric>
+        <metric name="bf16">1352.8501</metric>
       </test>
       <test name="joint-matrix-fp" display="joint_matrix float peak (every combination the device advertises)" unit="tflops" description="Peak speed of Intel&apos;s XMX matrix engine -- dedicated units that multiply whole blocks of numbers in one step rather than one value at a time -- across the reduced-precision formats AI work runs on. One row per input-type and tile shape the device advertises.">
         <metric name="joint_matrix_bf16" status="unsupported" reason="XMX matrix engine not available on this device"/>
@@ -41,19 +41,19 @@
         <metric name="joint_matrix_tf32" status="unsupported" reason="XMX matrix engine not available on this device"/>
       </test>
       <test name="onemkl-fp" display="oneMKL GEMM peak" unit="tflops" description="Matrix-multiply speed through Intel&apos;s own tuned library, on a large square problem. Where the joint_matrix rows show what the hardware can do in principle, this shows what shipping code reaches on the operation most AI work is built from.">
-        <metric name="fp32" info="Full 32-bit precision, on the general compute units rather than the matrix engine.">0.6539</metric>
-        <metric name="fp64" info="Full 64-bit precision, for scientific computing. Run on a smaller matrix than the other rows, because a full-size one would take long enough to trip the driver&apos;s watchdog.">0.3437</metric>
-        <metric name="fp16" info="16-bit inputs -- the everyday precision of AI inference, and usually the fastest row here.">0.5851</metric>
-        <metric name="bf16" info="bfloat16 inputs -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float.">0.5899</metric>
+        <metric name="fp32" info="Full 32-bit precision, on the general compute units rather than the matrix engine.">0.6536</metric>
+        <metric name="fp64" info="Full 64-bit precision, for scientific computing. Run on a smaller matrix than the other rows, because a full-size one would take long enough to trip the driver&apos;s watchdog.">0.3348</metric>
+        <metric name="fp16" info="16-bit inputs -- the everyday precision of AI inference, and usually the fastest row here.">0.5885</metric>
+        <metric name="bf16" info="bfloat16 inputs -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float.">0.5912</metric>
       </test>
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute (32-bit IMAD)" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">518.7410</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">518.9556</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">517.1458</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">517.7090</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">505.3273</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">518.7820</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">518.5316</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">516.8679</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">517.3729</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector SYCL offers.">505.7510</metric>
       </test>
       <test name="joint-matrix-int" display="joint_matrix integer peak (every combination the device advertises)" unit="tops" description="Peak speed of Intel&apos;s XMX matrix engine on 8-bit whole numbers -- dedicated units that multiply whole blocks of numbers in one step rather than one value at a time. This is the format quantized neural networks use. One row per A/B sign combination and tile shape the device advertises.">
         <metric name="joint_matrix_int8" info="8-bit whole numbers with 32-bit totals, the format quantized neural networks use." status="unsupported" reason="XMX matrix engine not available on this device"/>
@@ -64,9 +64,9 @@
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">30.9655</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">33.1472</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">35.1370</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">31.0631</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">33.2901</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">35.2927</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through local memory -- the small on-chip scratchpad a group of work-items passes data through, which never goes out to main memory.">
         <metric name="float" status="unsupported" reason="Device has no dedicated local memory (SYCL local_mem_type is global)"/>
@@ -74,17 +74,17 @@
         <metric name="float4" status="unsupported" reason="Device has no dedicated local memory (SYCL local_mem_type is global)"/>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">32.7544</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">33.6997</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is far narrower than either side&apos;s own memory; on integrated graphics the two share one pool and the numbers are much higher.">
-        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">10.5807</metric>
-        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">10.5104</metric>
+        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">10.5954</metric>
+        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">10.6239</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all, measured with an empty kernel. It is what small, frequent jobs pay before any of their own work begins.">
         <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it. SYCL exposes no clock the two share, so this is reported on some other backends but not here." status="unsupported" reason="Not measurable via SYCL runtime"/>
-        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">14.4325</metric>
+        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">14.5979</metric>
       </test>
     </category>
   </run>
@@ -93,24 +93,24 @@
     <prop name="VRAM" value="188708 MB"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">361.3110</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">541.5406</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">651.9484</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">354.7714</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">523.0122</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">624.1586</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute fp16xfp16+fp16" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on. Both the inputs and the running total stay 16-bit here.">
-        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">83.0709</metric>
-        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">91.8499</metric>
-        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">60.4569</metric>
+        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">100.3570</metric>
+        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">89.4997</metric>
+        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">69.2653</metric>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts deliberately run these many times slower than 32-bit.">
-        <metric name="double" info="One value per thread at a time -- the plain, unvectorised case.">201.5843</metric>
-        <metric name="double2" info="Two values per thread at a time, as one 2-wide vector.">263.6577</metric>
-        <metric name="double4" info="Four values per thread at a time, as one 4-wide vector.">264.1655</metric>
+        <metric name="double" info="One value per thread at a time -- the plain, unvectorised case.">201.5595</metric>
+        <metric name="double2" info="Two values per thread at a time, as one 2-wide vector.">269.1913</metric>
+        <metric name="double4" info="Four values per thread at a time, as one 4-wide vector.">260.9891</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
-        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">359.6899</metric>
-        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">566.2538</metric>
-        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">649.4648</metric>
+        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">651.8792</metric>
+        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">738.6271</metric>
+        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">718.7693</metric>
       </test>
       <test name="bfloat16_compute" display="BF16 compute bf16xbf16+fp32" unit="gflops" description="Peak speed on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the same number range as a full float. The running total is kept in 32 bits.">
         <metric name="bf16" info="One value per thread at a time -- the plain, unvectorised case." status="unsupported" reason="VK_KHR_shader_bfloat16 / shaderBFloat16Type not supported! Skipped"/>
@@ -120,8 +120,11 @@
       <test name="coopmat_fp32" display="Cooperative-matrix fp32xfp32+fp32" unit="tflops" description="Peak speed of the device&apos;s matrix engine (its tensor cores) on full 32-bit numbers. These units multiply whole small blocks of numbers in one step instead of one value at a time.">
         <metric name="coopmat_fp32" status="unsupported" reason="No fp32xfp32+fp32 coopmat property! Skipped"/>
       </test>
-      <test name="coopmat_fp16" display="Cooperative-matrix fp16xfp16+fp32 8x8x8" unit="tflops" description="The matrix engine on 16-bit inputs with a 32-bit running total -- the everyday precision of AI inference, and usually the fastest widely-supported row here.">
-        <metric name="coopmat_fp16">2.6738</metric>
+      <test name="coopmat_fp16" display="Cooperative-matrix fp16xfp16+fp32 8x8x8" unit="tflops" description="The matrix engine on 16-bit inputs with a 32-bit running total -- the everyday precision of AI inference, and the widest-supported row here. Keeping the total at 32 bits costs accuracy nothing and, on consumer graphics cards, costs half the speed: see the 16-bit-total row below.">
+        <metric name="coopmat_fp16">2.7402</metric>
+      </test>
+      <test name="coopmat_fp16_f16acc" display="Cooperative-matrix fp16xfp16+fp16 8x8x8" unit="tflops" description="The matrix engine on 16-bit inputs with the running total also kept at 16 bits. Consumer graphics cards run this at twice the rate of the 32-bit total above, which is why a card&apos;s headline AI figure is usually this one; server parts run both alike.">
+        <metric name="coopmat_fp16_f16acc">0.8647</metric>
       </test>
       <test name="coopmat_bf16" display="Cooperative-matrix bf16xbf16+fp32" unit="tflops" description="The matrix engine on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float, which makes training far more forgiving.">
         <metric name="coopmat_bf16" status="unsupported" reason="No bf16xbf16+fp32 coopmat support (shaderBFloat16Type or property)! Skipped"/>
@@ -135,42 +138,42 @@
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute int32" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per thread at a time -- the plain, unvectorised case.">304.2402</metric>
-        <metric name="int2" info="Two values per thread at a time, as one 2-wide vector.">336.8778</metric>
-        <metric name="int4" info="Four values per thread at a time, as one 4-wide vector.">386.1686</metric>
+        <metric name="int" info="One value per thread at a time -- the plain, unvectorised case.">290.0003</metric>
+        <metric name="int2" info="Two values per thread at a time, as one 2-wide vector.">334.9829</metric>
+        <metric name="int4" info="Four values per thread at a time, as one 4-wide vector.">376.9573</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
-        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">206.3355</metric>
-        <metric name="int8_dp2" info="Two independent chains, so the device has a second dot product to get on with while the first is still finishing.">258.1758</metric>
-        <metric name="int8_dp4" info="Four independent chains -- usually enough to keep the dot-product hardware busy with no waiting at all.">324.4008</metric>
+        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">209.4850</metric>
+        <metric name="int8_dp2" info="Two independent chains, so the device has a second dot product to get on with while the first is still finishing.">260.6503</metric>
+        <metric name="int8_dp4" info="Four independent chains -- usually enough to keep the dot-product hardware busy with no waiting at all.">313.9101</metric>
       </test>
       <test name="coopmat_int8" display="Cooperative-matrix int8xint8+int32 8x8x8" unit="tops" description="The matrix engine on 8-bit whole numbers with a 32-bit running total -- the format quantized neural networks use when they are squeezed down to run fast on cheaper hardware.">
-        <metric name="coopmat_int8">4.5667</metric>
+        <metric name="coopmat_int8">5.0054</metric>
       </test>
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">27.0122</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">29.7306</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">29.7267</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">27.2544</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">30.0937</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">29.9425</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through shared local memory -- the small on-chip scratchpad a group of threads passes data through, which never goes out to main memory.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">14.9207</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">27.4384</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">41.5977</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">15.1635</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">26.6805</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">40.3934</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">20.3763</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">20.1366</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is usually far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding.">
-        <metric name="h2d" info="Host to device: sending data across to the device.">17.0646</metric>
-        <metric name="d2h" info="Device to host: reading results back. Often slower than the other direction.">16.5873</metric>
+        <metric name="h2d" info="Host to device: sending data across to the device.">17.3823</metric>
+        <metric name="d2h" info="Device to host: reading results back. Often slower than the other direction.">17.0239</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all, measured with a shader that does no work. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it.">8.1956</metric>
-        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">148.5622</metric>
+        <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it.">8.6526</metric>
+        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">152.1513</metric>
       </test>
     </category>
   </run>
@@ -179,62 +182,62 @@
     <prop name="Clock frequency" value="0 MHz"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">1518.1257</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">1602.6405</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">1595.0759</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">417.7789</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1960.2222</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">1516.5846</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">1603.1028</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">1594.9182</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">416.6576</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1958.4659</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on.">
-        <metric name="half" info="One value per work-item at a time -- the plain, unvectorised case.">180.4009</metric>
-        <metric name="half2" info="Two values per work-item at a time, as one 2-wide vector.">176.7876</metric>
-        <metric name="half4" info="Four values per work-item at a time, as one 4-wide vector.">185.5093</metric>
-        <metric name="half8" info="Eight values per work-item at a time, as one 8-wide vector.">138.2483</metric>
-        <metric name="half16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">133.6362</metric>
+        <metric name="half" info="One value per work-item at a time -- the plain, unvectorised case.">180.4252</metric>
+        <metric name="half2" info="Two values per work-item at a time, as one 2-wide vector.">176.3203</metric>
+        <metric name="half4" info="Four values per work-item at a time, as one 4-wide vector.">185.3608</metric>
+        <metric name="half8" info="Eight values per work-item at a time, as one 8-wide vector.">138.4809</metric>
+        <metric name="half16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">133.7951</metric>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts deliberately run these many times slower than 32-bit.">
-        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">1023.0923</metric>
-        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">1023.8344</metric>
-        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">213.1625</metric>
-        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">420.3369</metric>
-        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">755.1699</metric>
+        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">1022.4338</metric>
+        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">1022.7310</metric>
+        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">212.4272</metric>
+        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">420.4329</metric>
+        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">753.3156</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
-        <metric name="mp" info="One value per work-item at a time -- the plain, unvectorised case.">376.1156</metric>
-        <metric name="mp2" info="Two values per work-item at a time, as one 2-wide vector.">95.2506</metric>
-        <metric name="mp4" info="Four values per work-item at a time, as one 4-wide vector.">96.1601</metric>
-        <metric name="mp8" info="Eight values per work-item at a time, as one 8-wide vector.">138.9822</metric>
-        <metric name="mp16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">258.3583</metric>
+        <metric name="mp" info="One value per work-item at a time -- the plain, unvectorised case.">1457.7683</metric>
+        <metric name="mp2" info="Two values per work-item at a time, as one 2-wide vector.">1366.1061</metric>
+        <metric name="mp4" info="Four values per work-item at a time, as one 4-wide vector.">209.6184</metric>
+        <metric name="mp8" info="Eight values per work-item at a time, as one 8-wide vector.">409.4149</metric>
+        <metric name="mp16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">775.4256</metric>
       </test>
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">518.8934</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">519.0879</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">514.8223</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">415.7594</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">518.7723</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">518.2100</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">517.3071</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">515.2227</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">416.0707</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">518.0516</metric>
       </test>
       <test name="integer_compute_fast" display="Integer compute Fast 24bit" unit="gops" description="The same integer maths restricted to 24-bit values, which some devices multiply on their faster floating-point hardware instead. Where this beats the plain integer row, the full 32-bit multiply is the slower path.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">517.3226</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">101.7965</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">203.9519</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">399.2404</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">518.2392</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">515.7056</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">101.4332</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">203.2443</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">399.2573</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">518.4706</metric>
       </test>
       <test name="integer_compute_char" display="Integer char (8bit) compute" unit="gops" description="Peak speed on 8-bit whole numbers, the smallest integer type -- worth knowing because image and quantized-AI work is full of them.">
-        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">908.1710</metric>
-        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">273.4882</metric>
-        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">983.1024</metric>
-        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">1530.4047</metric>
-        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1568.0062</metric>
+        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">907.2100</metric>
+        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">272.1147</metric>
+        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">979.0793</metric>
+        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">1527.2014</metric>
+        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1562.7368</metric>
       </test>
       <test name="integer_compute_short" display="Integer short (16bit) compute" unit="gops" description="Peak speed on 16-bit whole numbers -- the middle size, between the 8-bit and 32-bit rows.">
-        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">1030.5881</metric>
-        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">1044.8412</metric>
-        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">1971.4060</metric>
-        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">2012.9950</metric>
-        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">2008.8918</metric>
+        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">1030.5421</metric>
+        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">1041.6104</metric>
+        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">1966.4695</metric>
+        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">2011.3126</metric>
+        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">2008.3533</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
         <metric name="int8_dp" info="One value per work-item at a time -- the plain, unvectorised case." status="unsupported" reason="device&apos;s OpenCL compiler did not build these kernels"/>
@@ -246,11 +249,11 @@
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">31.0328</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">33.1995</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">34.6111</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">34.1326</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">33.6764</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">31.0821</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">33.3462</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">34.8192</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">34.4381</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">34.0079</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through local memory -- the small on-chip scratchpad a group of work-items passes data through, which never goes out to main memory.">
         <metric name="float" status="unsupported" reason="Device has no dedicated local memory (CL_DEVICE_LOCAL_MEM_TYPE is not CL_LOCAL)"/>
@@ -259,17 +262,17 @@
         <metric name="float8" status="unsupported" reason="Device has no dedicated local memory (CL_DEVICE_LOCAL_MEM_TYPE is not CL_LOCAL)"/>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">33.1294</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">32.6855</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding; where the two share one pool of memory the numbers are much higher. Both readings use pinned host memory, the fast path.">
-        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">10.5623</metric>
-        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">10.6043</metric>
+        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">10.6730</metric>
+        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">10.6685</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">2.8751</metric>
-        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">23.7394</metric>
+        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">3.0939</metric>
+        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">24.3484</metric>
       </test>
     </category>
   </run>
@@ -278,11 +281,11 @@
     <prop name="Clock frequency" value="4405 MHz"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">193.3897</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">204.7953</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">197.9993</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">397.0763</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">727.7155</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">172.2552</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">172.4601</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">192.8172</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">357.1485</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">757.2402</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on.">
         <metric name="half" status="unsupported" reason="No half precision support"/>
@@ -292,11 +295,11 @@
         <metric name="half16" status="unsupported" reason="No half precision support"/>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts deliberately run these many times slower than 32-bit.">
-        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">201.3748</metric>
-        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">191.4828</metric>
-        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">187.2874</metric>
-        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">388.6766</metric>
-        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">655.1301</metric>
+        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">169.6316</metric>
+        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">195.0186</metric>
+        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">202.3971</metric>
+        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">351.5873</metric>
+        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">611.3978</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
         <metric name="mp" status="unsupported" reason="No half precision support"/>
@@ -308,32 +311,32 @@
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">102.2921</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">105.0909</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">183.4986</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">354.8130</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">499.3488</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">111.5624</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">93.3719</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">198.8035</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">370.3800</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">462.4570</metric>
       </test>
       <test name="integer_compute_fast" display="Integer compute Fast 24bit" unit="gops" description="The same integer maths restricted to 24-bit values, which some devices multiply on their faster floating-point hardware instead. Where this beats the plain integer row, the full 32-bit multiply is the slower path.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">114.5820</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">94.6944</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">190.9145</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">350.9360</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">453.5811</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">123.2342</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">95.3774</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">198.4506</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">373.1570</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">471.8369</metric>
       </test>
       <test name="integer_compute_char" display="Integer char (8bit) compute" unit="gops" description="Peak speed on 8-bit whole numbers, the smallest integer type -- worth knowing because image and quantized-AI work is full of them.">
-        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">120.3619</metric>
-        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">111.8532</metric>
-        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">221.8635</metric>
-        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">452.8367</metric>
-        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">246.3599</metric>
+        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">118.5129</metric>
+        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">117.4323</metric>
+        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">214.8379</metric>
+        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">418.7733</metric>
+        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">243.7723</metric>
       </test>
       <test name="integer_compute_short" display="Integer short (16bit) compute" unit="gops" description="Peak speed on 16-bit whole numbers -- the middle size, between the 8-bit and 32-bit rows.">
-        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">119.1654</metric>
-        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">118.7132</metric>
-        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">231.0211</metric>
-        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">461.1493</metric>
-        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">976.6455</metric>
+        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">118.7725</metric>
+        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">123.2196</metric>
+        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">216.2519</metric>
+        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">511.4970</metric>
+        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">892.1946</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
         <metric name="int8_dp" status="unsupported" reason="cl_khr_integer_dot_product not supported"/>
@@ -345,11 +348,11 @@
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">30.6891</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">32.8621</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">34.3478</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">33.9088</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">33.5302</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">30.7495</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">32.6332</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">34.7686</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">34.2726</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">33.9259</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through local memory -- the small on-chip scratchpad a group of work-items passes data through, which never goes out to main memory.">
         <metric name="float" status="unsupported" reason="Device has no dedicated local memory (CL_DEVICE_LOCAL_MEM_TYPE is not CL_LOCAL)"/>
@@ -358,17 +361,17 @@
         <metric name="float8" status="unsupported" reason="Device has no dedicated local memory (CL_DEVICE_LOCAL_MEM_TYPE is not CL_LOCAL)"/>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">13.5498</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">13.2480</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding; where the two share one pool of memory the numbers are much higher. Both readings use pinned host memory, the fast path.">
-        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">16.3122</metric>
-        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">16.1295</metric>
+        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">16.3133</metric>
+        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">16.2859</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">29.5549</metric>
-        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">91.1703</metric>
+        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">29.5675</metric>
+        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">89.8087</metric>
       </test>
     </category>
   </run>
@@ -383,23 +386,23 @@
     <prop name="RAM" value="184.3 GB"/>
     <category name="fp_compute">
       <test name="single_precision_compute_sse2" display="Single-precision compute (SSE2)" unit="gflops" description="Peak arithmetic speed on 32-bit fractional numbers -- the ordinary float type most programs use. The data stays in registers, so only the CPU&apos;s vector units limit the rate.">
-        <metric name="float ST" info="One thread, running on a single core.">65.2080</metric>
-        <metric name="float MT" info="Every hardware thread at once -- the whole chip.">947.1674</metric>
+        <metric name="float ST" info="One thread, running on a single core.">65.2740</metric>
+        <metric name="float MT" info="Every hardware thread at once -- the whole chip.">945.6304</metric>
       </test>
       <test name="single_precision_compute_avx2_fma" display="Single-precision compute (AVX2+FMA)" unit="gflops" description="Peak arithmetic speed on 32-bit fractional numbers -- the ordinary float type most programs use. The data stays in registers, so only the CPU&apos;s vector units limit the rate.">
-        <metric name="float ST" info="One thread, running on a single core.">136.3067</metric>
-        <metric name="float MT" info="Every hardware thread at once -- the whole chip.">1914.4429</metric>
+        <metric name="float ST" info="One thread, running on a single core.">136.3113</metric>
+        <metric name="float MT" info="Every hardware thread at once -- the whole chip.">1910.9004</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and common in graphics and AI. Needs real 16-bit instructions, not conversion to 32-bit and back.">
         <metric name="half ST" status="unsupported" reason="no native fp16 arithmetic on this CPU"/>
       </test>
       <test name="double_precision_compute_sse2" display="Double-precision compute (SSE2)" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific and engineering code relies on.">
-        <metric name="double ST" info="One thread, running on a single core.">34.2297</metric>
-        <metric name="double MT" info="Every hardware thread at once -- the whole chip.">478.1122</metric>
+        <metric name="double ST" info="One thread, running on a single core.">34.1839</metric>
+        <metric name="double MT" info="Every hardware thread at once -- the whole chip.">478.1425</metric>
       </test>
       <test name="double_precision_compute_avx2_fma" display="Double-precision compute (AVX2+FMA)" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific and engineering code relies on.">
-        <metric name="double ST" info="One thread, running on a single core.">68.1581</metric>
-        <metric name="double MT" info="Every hardware thread at once -- the whole chip.">957.9975</metric>
+        <metric name="double ST" info="One thread, running on a single core.">68.1286</metric>
+        <metric name="double MT" info="Every hardware thread at once -- the whole chip.">955.9819</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the CPU multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses, done in one instruction with no conversion step.">
         <metric name="mp ST" status="unsupported" reason="no conversion-free fp16xfp16+fp32 widening FMA on this CPU"/>
@@ -411,36 +414,36 @@
         <metric name="bf16_fma ST" status="unsupported" reason="no native bf16 vector FMA (AVX10.2) on this CPU"/>
       </test>
       <test name="single_precision_divide_sse2" display="Single-precision divide (SSE2)" unit="gflops" description="How many divisions per second the CPU sustains. Division has its own narrow unit rather than the wide multiply-add pipeline, so it lands far below the compute rows and differs hugely between CPU generations.">
-        <metric name="fdiv ST" info="One thread, running on a single core.">4.9244</metric>
-        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">66.0104</metric>
+        <metric name="fdiv ST" info="One thread, running on a single core.">4.9296</metric>
+        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">65.9075</metric>
       </test>
       <test name="single_precision_divide_avx2" display="Single-precision divide (AVX2)" unit="gflops" description="How many divisions per second the CPU sustains. Division has its own narrow unit rather than the wide multiply-add pipeline, so it lands far below the compute rows and differs hugely between CPU generations.">
-        <metric name="fdiv ST" info="One thread, running on a single core.">9.7939</metric>
-        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">132.8169</metric>
+        <metric name="fdiv ST" info="One thread, running on a single core.">9.7738</metric>
+        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">133.2590</metric>
       </test>
       <test name="double_precision_divide_sse2" display="Double-precision divide (SSE2)" unit="gflops" description="How many divisions per second the CPU sustains. Division has its own narrow unit rather than the wide multiply-add pipeline, so it lands far below the compute rows and differs hugely between CPU generations.">
-        <metric name="fdiv ST" info="One thread, running on a single core.">1.7234</metric>
-        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">23.9196</metric>
+        <metric name="fdiv ST" info="One thread, running on a single core.">1.7247</metric>
+        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">23.8165</metric>
       </test>
       <test name="double_precision_divide_avx2" display="Double-precision divide (AVX2)" unit="gflops" description="How many divisions per second the CPU sustains. Division has its own narrow unit rather than the wide multiply-add pipeline, so it lands far below the compute rows and differs hugely between CPU generations.">
-        <metric name="fdiv ST" info="One thread, running on a single core.">3.4526</metric>
-        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">47.7835</metric>
+        <metric name="fdiv ST" info="One thread, running on a single core.">3.4471</metric>
+        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">47.8179</metric>
       </test>
       <test name="single_precision_sqrt_sse2" display="Single-precision sqrt (SSE2)" unit="gflops" description="How many square roots per second the CPU sustains. Like divide, this runs on a narrow dedicated unit instead of the main vector pipeline.">
-        <metric name="fsqrt ST" info="One thread, running on a single core.">3.1529</metric>
-        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">43.8775</metric>
+        <metric name="fsqrt ST" info="One thread, running on a single core.">3.1504</metric>
+        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">43.8960</metric>
       </test>
       <test name="single_precision_sqrt_avx2" display="Single-precision sqrt (AVX2)" unit="gflops" description="How many square roots per second the CPU sustains. Like divide, this runs on a narrow dedicated unit instead of the main vector pipeline.">
-        <metric name="fsqrt ST" info="One thread, running on a single core.">6.2982</metric>
-        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">88.1027</metric>
+        <metric name="fsqrt ST" info="One thread, running on a single core.">6.2949</metric>
+        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">87.6384</metric>
       </test>
       <test name="double_precision_sqrt_sse2" display="Double-precision sqrt (SSE2)" unit="gflops" description="How many square roots per second the CPU sustains. Like divide, this runs on a narrow dedicated unit instead of the main vector pipeline.">
-        <metric name="fsqrt ST" info="One thread, running on a single core.">1.0206</metric>
-        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">13.9196</metric>
+        <metric name="fsqrt ST" info="One thread, running on a single core.">1.0137</metric>
+        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">13.8463</metric>
       </test>
       <test name="double_precision_sqrt_avx2" display="Double-precision sqrt (AVX2)" unit="gflops" description="How many square roots per second the CPU sustains. Like divide, this runs on a narrow dedicated unit instead of the main vector pipeline.">
-        <metric name="fsqrt ST" info="One thread, running on a single core.">2.0355</metric>
-        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">27.5271</metric>
+        <metric name="fsqrt ST" info="One thread, running on a single core.">2.0302</metric>
+        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">27.5795</metric>
       </test>
       <test name="cpu_matrix_fp" display="CPU matrix engine (bf16)" unit="gflops" description="Peak speed of the CPU&apos;s built-in matrix engine -- Intel AMX tiles or Arm BFMMLA/SME, a small tensor unit beside the ordinary vector units -- on bfloat16 (AI-format) inputs.">
         <metric name="matrix_bf16 ST" status="unsupported" reason="no CPU bf16 matrix engine (AMX / BFMMLA / SME) on this CPU"/>
@@ -452,22 +455,22 @@
         <metric name="matrix_fp8 ST" status="unsupported" reason="no CPU fp8 matrix engine (AMX-FP8) on this CPU"/>
       </test>
       <test name="smt_scaling" display="SMT scaling (fp32 FMA)" unit="gflops" description="Whether the CPU&apos;s extra hardware threads (SMT, or Intel&apos;s Hyper-Threading) actually add throughput: the same maths kernel run once with one thread per physical core, then again on every thread the chip offers.">
-        <metric name="1T/core" info="One thread per physical core, with the extra hardware threads left idle.">2084.3442</metric>
-        <metric name="SMT MT" info="Every hardware thread busy, including the second thread sharing each core.">2082.0498</metric>
+        <metric name="1T/core" info="One thread per physical core, with the extra hardware threads left idle.">2082.5537</metric>
+        <metric name="SMT MT" info="Every hardware thread busy, including the second thread sharing each core.">2074.3992</metric>
       </test>
     </category>
     <category name="int_compute">
       <test name="integer_compute_sse2" display="Integer compute (SSE2)" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind array indexing, hashing, compression and address math.">
-        <metric name="int ST" info="One thread, running on a single core.">9.1995</metric>
-        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">197.0086</metric>
+        <metric name="int ST" info="One thread, running on a single core.">9.1906</metric>
+        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">199.5584</metric>
       </test>
       <test name="integer_compute_sse4_2" display="Integer compute (SSE4.2)" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind array indexing, hashing, compression and address math.">
-        <metric name="int ST" info="One thread, running on a single core.">17.2331</metric>
-        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">241.2057</metric>
+        <metric name="int ST" info="One thread, running on a single core.">17.1949</metric>
+        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">240.7230</metric>
       </test>
       <test name="integer_compute_avx2_fma" display="Integer compute (AVX2+FMA)" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind array indexing, hashing, compression and address math.">
-        <metric name="int ST" info="One thread, running on a single core.">34.3596</metric>
-        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">481.0979</metric>
+        <metric name="int ST" info="One thread, running on a single core.">34.2913</metric>
+        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">480.7002</metric>
       </test>
       <test name="int8_dot_product_compute" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit whole-number dot product, the workhorse instruction of quantized (compressed) neural networks running on the CPU.">
         <metric name="int8_dp ST" status="unsupported" reason="no int8 dot instruction on this CPU"/>
@@ -476,8 +479,8 @@
         <metric name="int16_dp ST" status="unsupported" reason="no int16 dot instruction on this CPU"/>
       </test>
       <test name="integer_divide_compute" display="Integer divide compute u64" unit="gops" description="How many 64-bit whole-number divisions the CPU sustains per second. No CPU has a vector integer divide, so this is one narrow scalar unit and usually the slowest instruction on the chip.">
-        <metric name="u64 ST" info="One thread, running on a single core.">0.1062</metric>
-        <metric name="u64 MT" info="Every hardware thread at once -- the whole chip.">1.4644</metric>
+        <metric name="u64 ST" info="One thread, running on a single core.">0.1059</metric>
+        <metric name="u64 MT" info="Every hardware thread at once -- the whole chip.">1.4584</metric>
       </test>
       <test name="cpu_matrix_int" display="CPU matrix engine (int8)" unit="gops" description="Peak speed of the CPU&apos;s built-in matrix engine -- Intel AMX tiles or Arm SMMLA/SME -- on 8-bit whole numbers, the format quantized neural networks use.">
         <metric name="matrix_int8 ST" status="unsupported" reason="no CPU int8 matrix engine (AMX / I8MM / SME) on this CPU"/>
@@ -485,86 +488,86 @@
     </category>
     <category name="crypto">
       <test name="aes_encrypt_aes_ni" display="AES-128 encrypt (AES-NI)" unit="gbps" description="How many bytes per second the CPU&apos;s dedicated AES instructions encrypt -- the ceiling for disk encryption and HTTPS traffic.">
-        <metric name="aes ST" info="One thread, running on a single core.">10.7431</metric>
-        <metric name="aes MT" info="Every hardware thread at once -- the whole chip.">159.0525</metric>
+        <metric name="aes ST" info="One thread, running on a single core.">10.7161</metric>
+        <metric name="aes MT" info="Every hardware thread at once -- the whole chip.">159.1009</metric>
       </test>
       <test name="sha256_hash_sha_ni" display="SHA-256 hash (SHA-NI)" unit="gbps" description="How many bytes per second the CPU hashes with SHA-256, the fingerprint function behind signatures, integrity checks and git-style content addressing.">
-        <metric name="sha256 ST" info="One thread, running on a single core.">3.5764</metric>
-        <metric name="sha256 MT" info="Every hardware thread at once -- the whole chip.">56.5234</metric>
+        <metric name="sha256 ST" info="One thread, running on a single core.">3.5687</metric>
+        <metric name="sha256 MT" info="Every hardware thread at once -- the whole chip.">56.3425</metric>
       </test>
       <test name="sha512_hash" display="SHA-512 hash" unit="gbps" description="How many bytes per second the CPU hashes with SHA-512, the wider member of the same family. Only Arm cores have an instruction for it today.">
         <metric name="sha512 ST" status="unsupported" reason="no SHA-512 instruction path on this CPU"/>
       </test>
       <test name="crc32c_sse4_2" display="CRC32-C checksum (SSE4.2)" unit="gbps" description="How many bytes per second the CPU checksums with CRC32-C, the corruption check storage and network stacks run over every block and packet.">
-        <metric name="crc32c ST" info="One thread, running on a single core.">34.5790</metric>
-        <metric name="crc32c MT" info="Every hardware thread at once -- the whole chip.">470.9837</metric>
+        <metric name="crc32c ST" info="One thread, running on a single core.">34.4307</metric>
+        <metric name="crc32c MT" info="Every hardware thread at once -- the whole chip.">471.7635</metric>
       </test>
     </category>
     <category name="string">
       <test name="string_scan_sse2" display="String scan (SSE2)" unit="gbps" description="How fast the CPU hunts through memory for one particular byte -- what memchr, strlen and every text search do. The data fits in L1 cache, so this is the scanning machinery, not memory speed.">
-        <metric name="byte_scan ST" info="One thread, running on a single core.">46.7401</metric>
-        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">690.5518</metric>
+        <metric name="byte_scan ST" info="One thread, running on a single core.">46.6769</metric>
+        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">691.9265</metric>
       </test>
       <test name="string_scan_sse4_2_pcmpistri" display="String scan (SSE4.2 PCMPISTRI)" unit="gbps" description="How fast the CPU hunts through memory for one particular byte -- what memchr, strlen and every text search do. The data fits in L1 cache, so this is the scanning machinery, not memory speed.">
-        <metric name="byte_scan ST" info="One thread, running on a single core.">29.7468</metric>
-        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">421.9482</metric>
+        <metric name="byte_scan ST" info="One thread, running on a single core.">29.6932</metric>
+        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">421.2284</metric>
       </test>
       <test name="string_scan_avx2" display="String scan (AVX2)" unit="gbps" description="How fast the CPU hunts through memory for one particular byte -- what memchr, strlen and every text search do. The data fits in L1 cache, so this is the scanning machinery, not memory speed.">
-        <metric name="byte_scan ST" info="One thread, running on a single core.">110.7237</metric>
-        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">1700.4033</metric>
+        <metric name="byte_scan ST" info="One thread, running on a single core.">110.9974</metric>
+        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">1701.8990</metric>
       </test>
       <test name="utf8_validate_ssse3" display="UTF-8 validate (SSSE3)" unit="gbps" description="How fast the CPU checks that text is well-formed UTF-8 -- the first thing every parser, browser and web server does to incoming text. Also run on L1-resident data.">
-        <metric name="utf8 ST" info="One thread, running on a single core.">9.0311</metric>
-        <metric name="utf8 MT" info="Every hardware thread at once -- the whole chip.">122.1357</metric>
+        <metric name="utf8 ST" info="One thread, running on a single core.">9.0113</metric>
+        <metric name="utf8 MT" info="Every hardware thread at once -- the whole chip.">121.9907</metric>
       </test>
       <test name="utf8_validate_avx2" display="UTF-8 validate (AVX2)" unit="gbps" description="How fast the CPU checks that text is well-formed UTF-8 -- the first thing every parser, browser and web server does to incoming text. Also run on L1-resident data.">
-        <metric name="utf8 ST" info="One thread, running on a single core.">19.2119</metric>
-        <metric name="utf8 MT" info="Every hardware thread at once -- the whole chip.">269.3987</metric>
+        <metric name="utf8 ST" info="One thread, running on a single core.">19.1631</metric>
+        <metric name="utf8 MT" info="Every hardware thread at once -- the whole chip.">268.7556</metric>
       </test>
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="DRAM bandwidth" unit="gbps" description="How many bytes per second all cores together can move to and from main memory. The arrays are far too big for any cache, so every access goes out to RAM.">
-        <metric name="read" info="Reading one large array straight through, start to end.">38.3036</metric>
-        <metric name="copy" info="Copying one large array into another -- a read and a write for every element.">33.7118</metric>
-        <metric name="triad" info="Scaling one array, adding a second and storing to a third: two reads and a write per element, the hardest of the three.">23.1003</metric>
+        <metric name="read" info="Reading one large array straight through, start to end.">38.2964</metric>
+        <metric name="copy" info="Copying one large array into another -- a read and a write for every element.">33.7581</metric>
+        <metric name="triad" info="Scaling one array, adding a second and storing to a third: two reads and a write per element, the hardest of the three.">23.2630</metric>
       </test>
       <test name="cache_bandwidth" display="Cache bandwidth (read)" unit="gbps" description="How many bytes per second the CPU can read out of each cache, from the tiny fast one next to the core to the big slow one shared by all of them. Each reading uses a working set sized to stay inside the cache it names.">
-        <metric name="L1 ST" info="One thread reading from the small cache inside its own core.">252.7341</metric>
-        <metric name="L1 MT" info="Every core reading from its own L1 at the same time.">3902.3860</metric>
-        <metric name="L2 ST" info="One thread reading from the mid-level cache, the next step out.">134.1894</metric>
-        <metric name="L2 MT" info="Every core reading from L2 at once; where L2 is shared, the data is split between them so it still fits.">1681.8817</metric>
-        <metric name="L3 ST" info="One thread reading from the large cache shared by all cores.">97.9612</metric>
-        <metric name="L3 MT" info="Every core reading from that shared cache at once, each taking a slice of it.">1688.5333</metric>
+        <metric name="L1 ST" info="One thread reading from the small cache inside its own core.">252.7785</metric>
+        <metric name="L1 MT" info="Every core reading from its own L1 at the same time.">3785.6653</metric>
+        <metric name="L2 ST" info="One thread reading from the mid-level cache, the next step out.">135.0364</metric>
+        <metric name="L2 MT" info="Every core reading from L2 at once; where L2 is shared, the data is split between them so it still fits.">1744.5148</metric>
+        <metric name="L3 ST" info="One thread reading from the large cache shared by all cores.">96.5718</metric>
+        <metric name="L3 MT" info="Every core reading from that shared cache at once, each taking a slice of it.">1758.8481</metric>
       </test>
       <test name="l1_write_bandwidth" display="L1 bandwidth (write / copy)" unit="gbps" description="How many bytes per second a core can write into its nearest cache, and copy within it. Cores have fewer paths out to memory than in, so writing usually lands below the matching read row.">
-        <metric name="write ST" info="One thread storing new values into its own L1.">132.1051</metric>
-        <metric name="write MT" info="Every core storing into its own L1 at the same time.">1701.9302</metric>
-        <metric name="copy ST" info="One thread copying inside L1 -- one read plus one write for every byte moved.">266.1201</metric>
-        <metric name="copy MT" info="Every core copying inside its own L1 at the same time.">4150.2256</metric>
+        <metric name="write ST" info="One thread storing new values into its own L1.">132.2932</metric>
+        <metric name="write MT" info="Every core storing into its own L1 at the same time.">1682.7104</metric>
+        <metric name="copy ST" info="One thread copying inside L1 -- one read plus one write for every byte moved.">265.7860</metric>
+        <metric name="copy MT" info="Every core copying inside its own L1 at the same time.">3967.7324</metric>
       </test>
     </category>
     <category name="latency">
       <test name="memory_latency" display="Memory latency (pointer-chase)" unit="ns" description="How long the core waits for one memory read when it has nothing else to do -- each read&apos;s address comes from the previous read, so the hardware cannot start the next one early.">
-        <metric name="L1" info="Reading from the small cache inside the core.">1.1496</metric>
-        <metric name="L2" info="Reading from the mid-level cache, after an L1 miss.">3.0272</metric>
-        <metric name="L3" info="Reading from the last-level cache shared between cores.">10.4414</metric>
-        <metric name="DRAM" info="Reading from main memory at random -- the worst case.">111.5594</metric>
-        <metric name="DRAM linear" info="Main memory again, but read in address order, so the hardware can fetch ahead -- the best case DRAM gets.">4.4722</metric>
-        <metric name="DRAM x8" info="Eight independent chases at once: the reads overlap instead of waiting in turn, so each costs less.">15.0204</metric>
-        <metric name="DRAM x32" info="Thirty-two chases at once -- deep enough that the core runs out of room for further overlap, so the cost per read stops falling.">6.0119</metric>
-        <metric name="TLB miss" info="The address-translation cost on its own: the data is cached, but every read lands on a different page.">18.4633</metric>
+        <metric name="L1" info="Reading from the small cache inside the core.">1.1506</metric>
+        <metric name="L2" info="Reading from the mid-level cache, after an L1 miss.">3.0462</metric>
+        <metric name="L3" info="Reading from the last-level cache shared between cores.">10.5903</metric>
+        <metric name="DRAM" info="Reading from main memory at random -- the worst case.">111.7920</metric>
+        <metric name="DRAM linear" info="Main memory again, but read in address order, so the hardware can fetch ahead -- the best case DRAM gets.">4.4589</metric>
+        <metric name="DRAM x8" info="Eight independent chases at once: the reads overlap instead of waiting in turn, so each costs less.">15.0076</metric>
+        <metric name="DRAM x32" info="Thirty-two chases at once -- deep enough that the core runs out of room for further overlap, so the cost per read stops falling.">5.9945</metric>
+        <metric name="TLB miss" info="The address-translation cost on its own: the data is cached, but every read lands on a different page.">17.3080</metric>
       </test>
       <test name="atomics" display="Atomic fetch-add latency" unit="ns" description="How long one all-or-nothing counter update takes. This is the operation behind locks, reference counts and every shared data structure, so it sets the cost of coordinating between threads.">
-        <metric name="uncontended ST" info="One thread updating a counter nobody else touches, so it stays in that core&apos;s own cache.">4.0756</metric>
-        <metric name="contended MT" info="Every core fighting over the same counter, which has to be handed from core to core -- the time between completed updates anywhere on the chip.">8.9768</metric>
+        <metric name="uncontended ST" info="One thread updating a counter nobody else touches, so it stays in that core&apos;s own cache.">4.2130</metric>
+        <metric name="contended MT" info="Every core fighting over the same counter, which has to be handed from core to core -- the time between completed updates anywhere on the chip.">8.9699</metric>
       </test>
       <test name="branch_mispredict" display="Branch mispredict penalty" unit="ns" description="What it costs when the CPU guesses the wrong way at an if-statement. The same loop runs over sorted data (easy to guess) and shuffled data (a coin flip), and the difference is the price of a wrong guess.">
-        <metric name="predicted" info="Time per if-statement on sorted data, where the CPU guesses right every time.">0.2774</metric>
-        <metric name="random" info="Time per if-statement on shuffled data, where the CPU is wrong about half the time.">3.1024</metric>
-        <metric name="penalty" info="The extra time one wrong guess costs, worked out from the gap between the other two readings.">5.6499</metric>
+        <metric name="predicted" info="Time per if-statement on sorted data, where the CPU guesses right every time.">0.2771</metric>
+        <metric name="random" info="Time per if-statement on shuffled data, where the CPU is wrong about half the time.">3.1716</metric>
+        <metric name="penalty" info="The extra time one wrong guess costs, worked out from the gap between the other two readings.">5.7890</metric>
       </test>
       <test name="store_forward" display="Store-to-load forwarding" unit="ns" description="How fast the core can read back a value it just wrote, without the write having reached the cache yet.">
-        <metric name="st-&gt;ld ST">0.2325</metric>
+        <metric name="st-&gt;ld ST">0.2324</metric>
       </test>
     </category>
   </run>

--- a/results/Apple/M1_Pro.xml
+++ b/results/Apple/M1_Pro.xml
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<clpeak format_version="2" clpeak_version="2.1.2-64-g71043e1" os="Macintosh">
+<clpeak format_version="2" clpeak_version="2.1.2-69-g940fa86" os="Macintosh">
   <run backend="Metal" platform="Metal" device="Apple M1 Pro" driver="macOS 26.6.2">
     <prop name="Apple family" value="Apple7"/>
     <prop name="Working set" value="25559 MB"/>
     <prop name="GPU cores" value="16"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the GPU&apos;s shader cores on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4476.0986</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">4822.7666</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">5005.9868</metric>
-        <metric name="float8" info="Eight values per thread at a time, as one 8-wide vector.">5122.3599</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4476.1489</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">4824.2256</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">5006.2539</metric>
+        <metric name="float8" info="Eight values per thread at a time, as one 8-wide vector.">5123.1274</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on.">
-        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">4472.9336</metric>
-        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">4855.7959</metric>
-        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">5089.6470</metric>
-        <metric name="half8" info="Eight values per thread at a time, as one 8-wide vector.">5153.7529</metric>
+        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">4473.7451</metric>
+        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">4856.6538</metric>
+        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">5089.9536</metric>
+        <metric name="half8" info="Eight values per thread at a time, as one 8-wide vector.">5155.0371</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the GPU multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
-        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">4471.5615</metric>
-        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">4955.0688</metric>
-        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">4950.6289</metric>
+        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">5158.5127</metric>
+        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">5223.9487</metric>
+        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">5208.4116</metric>
       </test>
       <test name="simdgroup_matrix_fp16" display="simdgroup_matrix fp16xfp16+fp32 8x8x8" unit="tflops" description="Peak speed of Apple&apos;s matrix instruction, which multiplies whole 8x8 blocks of 16-bit numbers in one step instead of one value at a time -- the GPU&apos;s answer to a tensor core.">
-        <metric name="simdgroup_fp16">5.1305</metric>
+        <metric name="simdgroup_fp16">5.1351</metric>
       </test>
       <test name="simdgroup_matrix_bf16" display="simdgroup_matrix bf16xbf16+fp32 8x8x8" unit="tflops" description="The same 8x8 block matrix instruction on bfloat16, the AI-oriented 16-bit format that trades digits of accuracy for a wider number range. Needs an M3 or newer GPU.">
         <metric name="simdgroup_bf16" status="unsupported" reason="bf16 simdgroup_matrix requires Apple9 (M3) or newer! Skipped"/>
       </test>
       <test name="mps-gemm-fp" display="MPS GEMM peak" unit="tflops" description="Matrix-multiply speed through Apple&apos;s own tuned GPU library, on a large square problem. Where the compute rows show what the hardware can do in principle, this shows what Apple&apos;s shipping code actually reaches on the operation most graphics and AI work is built from.">
-        <metric name="fp32" info="Full 32-bit precision, the accurate but slowest option.">4.1086</metric>
-        <metric name="fp16" info="16-bit inputs, which the GPU&apos;s matrix hardware runs at several times the 32-bit rate.">3.9747</metric>
+        <metric name="fp32" info="Full 32-bit precision, the accurate but slowest option.">4.0451</metric>
+        <metric name="fp16" info="16-bit inputs, which the GPU&apos;s matrix hardware runs at several times the 32-bit rate.">3.9705</metric>
         <metric name="bf16" info="bfloat16 inputs -- 16 bits arranged for AI work, trading digits of accuracy for a wider number range. Needs an M3 or newer GPU." status="unsupported" reason="bf16 requires Apple9 (M3) -- unsupported on this device"/>
       </test>
       <test name="mps-attention" display="MPS attention SDPA (H16 S4096 D128)" unit="tflops" description="Speed of the attention step -- the operation a language model spends most of its time in, deciding which earlier words each word should look at. Apple&apos;s library runs it as one fused unit; the shape is fixed at a small-LLM size so the number compares across devices.">
-        <metric name="fp16">2.9255</metric>
+        <metric name="fp16">2.9013</metric>
       </test>
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the GPU can stream out of main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">181.3661</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">183.5658</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">182.3503</metric>
-        <metric name="float8" info="Eight values per thread at a time, as one 8-wide vector.">183.3653</metric>
-        <metric name="float16" info="Sixteen values per thread at a time, the widest vector Metal offers.">183.0691</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">180.0044</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">184.0180</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">183.0635</metric>
+        <metric name="float8" info="Eight values per thread at a time, as one 8-wide vector.">183.4709</metric>
+        <metric name="float16" info="Sixteen values per thread at a time, the widest vector Metal offers.">182.8759</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the GPU moves through threadgroup memory -- the small scratchpad a group of threads shares on-chip, which never goes out to main memory.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">2937.4617</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">2766.5286</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">2705.1995</metric>
-        <metric name="float8" info="Eight values per thread at a time, as one 8-wide vector.">2583.9404</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">2938.6750</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">2767.1331</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">2706.5681</metric>
+        <metric name="float8" info="Eight values per thread at a time, as one 8-wide vector.">2581.3508</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the GPU reads through its texture units, which take a different path to memory than plain buffer reads. Each reading uses a different pixel format, so they differ in how many bytes one pixel costs.">
-        <metric name="rgba32f" info="Four colour channels at full 32-bit precision: 16 bytes a pixel, the heaviest format here.">161.8814</metric>
-        <metric name="rgba16f" info="Four channels at half precision: 8 bytes a pixel.">151.7614</metric>
-        <metric name="rgba8" info="Four 8-bit channels: 4 bytes a pixel, the format ordinary images use.">96.8029</metric>
-        <metric name="r32f" info="A single 32-bit channel: also 4 bytes a pixel, but one value instead of four.">97.5929</metric>
+        <metric name="rgba32f" info="Four colour channels at full 32-bit precision: 16 bytes a pixel, the heaviest format here.">160.6822</metric>
+        <metric name="rgba16f" info="Four channels at half precision: 8 bytes a pixel.">152.5604</metric>
+        <metric name="rgba8" info="Four 8-bit channels: 4 bytes a pixel, the format ordinary images use.">96.9023</metric>
+        <metric name="r32f" info="A single 32-bit channel: also 4 bytes a pixel, but one value instead of four.">97.3580</metric>
       </test>
       <test name="texture_sample_rate" display="Texture sample rate (bilinear)" unit="gtexels" description="How many filtered texture lookups per second the GPU&apos;s sampling hardware performs. Every lookup falls between pixels, so the hardware must blend four of them -- the basic operation of drawing any textured surface. The texture is small enough to stay cached, so this measures the sampling units rather than memory.">
-        <metric name="rgba8" info="Blending four 8-bit-per-channel pixels, the common case in games and UI.">114.8446</metric>
-        <metric name="rgba16f" info="Blending four half-precision pixels -- twice the data per lookup, so the rate typically drops.">91.8159</metric>
+        <metric name="rgba8" info="Blending four 8-bit-per-channel pixels, the common case in games and UI.">114.3875</metric>
+        <metric name="rgba16f" info="Blending four half-precision pixels -- twice the data per lookup, so the rate typically drops.">91.8100</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the GPU to do anything at all, measured with a kernel that does no work. It is what small, frequent GPU jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the CPU submits the work to the moment the GPU starts running it.">5.8108</metric>
-        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the CPU waits for if it has nothing else to get on with.">188.6334</metric>
+        <metric name="dispatch" info="One way only: from the moment the CPU submits the work to the moment the GPU starts running it.">5.2645</metric>
+        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the CPU waits for if it has nothing else to get on with.">186.5695</metric>
       </test>
     </category>
   </run>
@@ -74,14 +74,14 @@
     <prop name="VRAM" value="32768 MB"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4403.5142</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">4789.5518</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">4976.9014</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4337.1812</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">4788.6167</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">4974.3398</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute fp16xfp16+fp16" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on. Both the inputs and the running total stay 16-bit here.">
-        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">4622.0352</metric>
-        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">4830.2734</metric>
-        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">4994.0312</metric>
+        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">4447.6875</metric>
+        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">4831.0015</metric>
+        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">4994.7495</metric>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts deliberately run these many times slower than 32-bit.">
         <metric name="double" info="One value per thread at a time -- the plain, unvectorised case." status="unsupported" reason="shaderFloat64 not supported! Skipped"/>
@@ -89,9 +89,9 @@
         <metric name="double4" info="Four values per thread at a time, as one 4-wide vector." status="unsupported" reason="shaderFloat64 not supported! Skipped"/>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
-        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">4446.6680</metric>
-        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">4928.8286</metric>
-        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">5063.7119</metric>
+        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">5126.1245</metric>
+        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">5191.1855</metric>
+        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">5204.6968</metric>
       </test>
       <test name="bfloat16_compute" display="BF16 compute bf16xbf16+fp32" unit="gflops" description="Peak speed on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the same number range as a full float. The running total is kept in 32 bits.">
         <metric name="bf16" info="One value per thread at a time -- the plain, unvectorised case." status="unsupported" reason="VK_KHR_shader_bfloat16 / shaderBFloat16Type not supported! Skipped"/>
@@ -101,8 +101,11 @@
       <test name="coopmat_fp32" display="Cooperative-matrix fp32xfp32+fp32" unit="tflops" description="Peak speed of the device&apos;s matrix engine (its tensor cores) on full 32-bit numbers. These units multiply whole small blocks of numbers in one step instead of one value at a time.">
         <metric name="coopmat_fp32" status="unsupported" reason="No fp32xfp32+fp32 coopmat property! Skipped"/>
       </test>
-      <test name="coopmat_fp16" display="Cooperative-matrix fp16xfp16+fp32" unit="tflops" description="The matrix engine on 16-bit inputs with a 32-bit running total -- the everyday precision of AI inference, and usually the fastest widely-supported row here.">
+      <test name="coopmat_fp16" display="Cooperative-matrix fp16xfp16+fp32" unit="tflops" description="The matrix engine on 16-bit inputs with a 32-bit running total -- the everyday precision of AI inference, and the widest-supported row here. Keeping the total at 32 bits costs accuracy nothing and, on consumer graphics cards, costs half the speed: see the 16-bit-total row below.">
         <metric name="coopmat_fp16" status="unsupported" reason="No fp16xfp16+fp32 coopmat support (shaderFloat16 or property)! Skipped"/>
+      </test>
+      <test name="coopmat_fp16_f16acc" display="Cooperative-matrix fp16xfp16+fp16" unit="tflops" description="The matrix engine on 16-bit inputs with the running total also kept at 16 bits. Consumer graphics cards run this at twice the rate of the 32-bit total above, which is why a card&apos;s headline AI figure is usually this one; server parts run both alike.">
+        <metric name="coopmat_fp16_f16acc" status="unsupported" reason="No fp16xfp16+fp16 coopmat support (shaderFloat16 or property)! Skipped"/>
       </test>
       <test name="coopmat_bf16" display="Cooperative-matrix bf16xbf16+fp32" unit="tflops" description="The matrix engine on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float, which makes training far more forgiving.">
         <metric name="coopmat_bf16" status="unsupported" reason="No bf16xbf16+fp32 coopmat support (shaderBFloat16Type or property)! Skipped"/>
@@ -116,14 +119,14 @@
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute int32" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per thread at a time -- the plain, unvectorised case.">1320.9391</metric>
-        <metric name="int2" info="Two values per thread at a time, as one 2-wide vector.">1320.0868</metric>
-        <metric name="int4" info="Four values per thread at a time, as one 4-wide vector.">1321.7448</metric>
+        <metric name="int" info="One value per thread at a time -- the plain, unvectorised case.">1321.6279</metric>
+        <metric name="int2" info="Two values per thread at a time, as one 2-wide vector.">1321.4368</metric>
+        <metric name="int4" info="Four values per thread at a time, as one 4-wide vector.">1321.8320</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
-        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">378.6172</metric>
-        <metric name="int8_dp2" info="Two independent chains, so the device has a second dot product to get on with while the first is still finishing.">378.4604</metric>
-        <metric name="int8_dp4" info="Four independent chains -- usually enough to keep the dot-product hardware busy with no waiting at all.">378.3195</metric>
+        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">378.6723</metric>
+        <metric name="int8_dp2" info="Two independent chains, so the device has a second dot product to get on with while the first is still finishing.">378.6005</metric>
+        <metric name="int8_dp4" info="Four independent chains -- usually enough to keep the dot-product hardware busy with no waiting at all.">378.2279</metric>
       </test>
       <test name="coopmat_int8" display="Cooperative-matrix int8xint8+int32" unit="tops" description="The matrix engine on 8-bit whole numbers with a 32-bit running total -- the format quantized neural networks use when they are squeezed down to run fast on cheaper hardware.">
         <metric name="coopmat_int8" status="unsupported" reason="No int8xint8+int32 coopmat support (shaderInt8 or property)! Skipped"/>
@@ -131,27 +134,27 @@
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">175.6119</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">177.2607</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">176.0833</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">176.6319</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">178.2863</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">177.4742</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through shared local memory -- the small on-chip scratchpad a group of threads passes data through, which never goes out to main memory.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">2541.5352</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">2582.3298</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">2604.7065</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">2539.6868</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">2586.6487</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">2604.3945</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">154.8542</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">153.6243</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is usually far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding.">
-        <metric name="h2d" info="Host to device: sending data across to the device.">92.1263</metric>
-        <metric name="d2h" info="Device to host: reading results back. Often slower than the other direction.">92.2125</metric>
+        <metric name="h2d" info="Host to device: sending data across to the device.">92.4674</metric>
+        <metric name="d2h" info="Device to host: reading results back. Often slower than the other direction.">92.3995</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all, measured with a shader that does no work. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it.">143.8938</metric>
-        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">307.3820</metric>
+        <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it.">140.9832</metric>
+        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">306.6041</metric>
       </test>
     </category>
   </run>
@@ -160,11 +163,11 @@
     <prop name="Clock frequency" value="1000 MHz"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">4461.5562</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">4812.4995</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">4988.8271</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">5105.1768</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">5219.0024</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">4461.4722</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">4813.0850</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">4995.6523</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">5107.5752</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">5223.1016</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on.">
         <metric name="half" status="unsupported" reason="No half precision support"/>
@@ -190,32 +193,32 @@
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">1324.5796</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">1323.8844</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">1324.5492</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">1324.2017</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1345.5300</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">1324.5023</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">1323.7769</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">1324.5686</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">1324.4720</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1345.3165</metric>
       </test>
       <test name="integer_compute_fast" display="Integer compute Fast 24bit" unit="gops" description="The same integer maths restricted to 24-bit values, which some devices multiply on their faster floating-point hardware instead. Where this beats the plain integer row, the full 32-bit multiply is the slower path.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">1243.3503</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">1246.9187</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">1246.4821</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">1246.4380</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1246.3838</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">1243.5997</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">1246.6604</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">1246.1823</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">1246.1875</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1245.9240</metric>
       </test>
       <test name="integer_compute_char" display="Integer char (8bit) compute" unit="gops" description="Peak speed on 8-bit whole numbers, the smallest integer type -- worth knowing because image and quantized-AI work is full of them.">
-        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">1321.7373</metric>
-        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">1324.5050</metric>
-        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">1324.5575</metric>
-        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">1324.6984</metric>
-        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1345.3303</metric>
+        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">1321.6272</metric>
+        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">1324.4885</metric>
+        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">1324.6653</metric>
+        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">1324.6653</metric>
+        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1345.8185</metric>
       </test>
       <test name="integer_compute_short" display="Integer short (16bit) compute" unit="gops" description="Peak speed on 16-bit whole numbers -- the middle size, between the 8-bit and 32-bit rows.">
-        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">1324.6210</metric>
-        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">1324.4333</metric>
-        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">1324.5575</metric>
-        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">1324.1299</metric>
-        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1345.8657</metric>
+        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">1324.2816</metric>
+        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">1324.2263</metric>
+        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">1324.6320</metric>
+        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">1324.3533</metric>
+        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">1345.2279</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
         <metric name="int8_dp" status="unsupported" reason="cl_khr_integer_dot_product not supported"/>
@@ -227,30 +230,30 @@
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">180.0685</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">180.8219</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">181.1660</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">157.8666</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">95.7985</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">179.5924</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">182.2932</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">182.3241</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">156.3857</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">93.2305</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through local memory -- the small on-chip scratchpad a group of work-items passes data through, which never goes out to main memory.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">1491.1564</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">2151.8840</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">2338.3662</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">1664.6179</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">1491.3988</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">2151.7175</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">2338.9883</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">1664.6213</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">168.6225</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">170.7487</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding; where the two share one pool of memory the numbers are much higher. Both readings use pinned host memory, the fast path.">
-        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">53.6181</metric>
-        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">53.9821</metric>
+        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">54.4756</metric>
+        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">55.1025</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">2.0619</metric>
-        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">184.9904</metric>
+        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">2.2052</metric>
+        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">191.6915</metric>
       </test>
     </category>
   </run>
@@ -264,20 +267,20 @@
     <prop name="RAM" value="32.0 GB"/>
     <category name="fp_compute">
       <test name="single_precision_compute_neon" display="Single-precision compute (NEON)" unit="gflops" description="Peak arithmetic speed on 32-bit fractional numbers -- the ordinary float type most programs use. The data stays in registers, so only the CPU&apos;s vector units limit the rate.">
-        <metric name="float ST" info="One thread, running on a single core.">101.2479</metric>
-        <metric name="float MT" info="Every hardware thread at once -- the whole chip.">808.8447</metric>
+        <metric name="float ST" info="One thread, running on a single core.">101.9393</metric>
+        <metric name="float MT" info="Every hardware thread at once -- the whole chip.">822.7044</metric>
       </test>
       <test name="half_precision_compute_neon_fp16" display="Half-precision compute (NEON FP16)" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and common in graphics and AI. Needs real 16-bit instructions, not conversion to 32-bit and back.">
-        <metric name="half ST" info="One thread, running on a single core.">200.8173</metric>
-        <metric name="half MT" info="Every hardware thread at once -- the whole chip.">1610.7028</metric>
+        <metric name="half ST" info="One thread, running on a single core.">201.6995</metric>
+        <metric name="half MT" info="Every hardware thread at once -- the whole chip.">1634.1102</metric>
       </test>
       <test name="double_precision_compute_neon" display="Double-precision compute (NEON)" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific and engineering code relies on.">
-        <metric name="double ST" info="One thread, running on a single core.">50.1873</metric>
-        <metric name="double MT" info="Every hardware thread at once -- the whole chip.">400.8909</metric>
+        <metric name="double ST" info="One thread, running on a single core.">50.1692</metric>
+        <metric name="double MT" info="Every hardware thread at once -- the whole chip.">393.7359</metric>
       </test>
       <test name="mixed_precision_compute_neon_fp16fml" display="Mixed-precision compute fp16xfp16+fp32 (NEON FP16FML)" unit="gflops" description="Peak speed when the CPU multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses, done in one instruction with no conversion step.">
-        <metric name="mp ST" info="One thread, running on a single core.">46.6121</metric>
-        <metric name="mp MT" info="Every hardware thread at once -- the whole chip.">390.7666</metric>
+        <metric name="mp ST" info="One thread, running on a single core.">46.7293</metric>
+        <metric name="mp MT" info="Every hardware thread at once -- the whole chip.">388.2177</metric>
       </test>
       <test name="bfloat16_compute" display="BF16 compute bf16xbf16+fp32" unit="gflops" description="Peak speed of the bfloat16 dot-product instruction, which multiplies pairs of 16-bit AI-format numbers and adds the results into a 32-bit running total.">
         <metric name="bf16 ST" status="unsupported" reason="no bf16 dot instruction on this CPU"/>
@@ -286,20 +289,20 @@
         <metric name="fp8_dp ST" status="unsupported" reason="no fp8 dot instruction (FEAT_FP8DOT4) on this CPU"/>
       </test>
       <test name="single_precision_divide_neon" display="Single-precision divide (NEON)" unit="gflops" description="How many divisions per second the CPU sustains. Division has its own narrow unit rather than the wide multiply-add pipeline, so it lands far below the compute rows and differs hugely between CPU generations.">
-        <metric name="fdiv ST" info="One thread, running on a single core.">9.2329</metric>
-        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">76.2459</metric>
+        <metric name="fdiv ST" info="One thread, running on a single core.">9.2852</metric>
+        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">76.7286</metric>
       </test>
       <test name="double_precision_divide_neon" display="Double-precision divide (NEON)" unit="gflops" description="How many divisions per second the CPU sustains. Division has its own narrow unit rather than the wide multiply-add pipeline, so it lands far below the compute rows and differs hugely between CPU generations.">
-        <metric name="fdiv ST" info="One thread, running on a single core.">3.9040</metric>
-        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">32.5983</metric>
+        <metric name="fdiv ST" info="One thread, running on a single core.">3.9292</metric>
+        <metric name="fdiv MT" info="Every hardware thread at once -- the whole chip.">33.3742</metric>
       </test>
       <test name="single_precision_sqrt_neon" display="Single-precision sqrt (NEON)" unit="gflops" description="How many square roots per second the CPU sustains. Like divide, this runs on a narrow dedicated unit instead of the main vector pipeline.">
-        <metric name="fsqrt ST" info="One thread, running on a single core.">6.3755</metric>
-        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">51.6036</metric>
+        <metric name="fsqrt ST" info="One thread, running on a single core.">6.3844</metric>
+        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">51.1616</metric>
       </test>
       <test name="double_precision_sqrt_neon" display="Double-precision sqrt (NEON)" unit="gflops" description="How many square roots per second the CPU sustains. Like divide, this runs on a narrow dedicated unit instead of the main vector pipeline.">
-        <metric name="fsqrt ST" info="One thread, running on a single core.">3.1939</metric>
-        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">25.3061</metric>
+        <metric name="fsqrt ST" info="One thread, running on a single core.">3.1936</metric>
+        <metric name="fsqrt MT" info="Every hardware thread at once -- the whole chip.">25.8241</metric>
       </test>
       <test name="cpu_matrix_fp" display="CPU matrix engine (bf16)" unit="gflops" description="Peak speed of the CPU&apos;s built-in matrix engine -- Intel AMX tiles or Arm BFMMLA/SME, a small tensor unit beside the ordinary vector units -- on bfloat16 (AI-format) inputs.">
         <metric name="matrix_bf16 ST" status="unsupported" reason="no CPU bf16 matrix engine (AMX / BFMMLA / SME) on this CPU"/>
@@ -314,13 +317,13 @@
         <metric name="matrix_fp64 ST" status="unsupported" reason="no CPU fp64 matrix engine (SME F64F64) on this CPU"/>
       </test>
       <test name="accelerate_gemm" display="Accelerate GEMM (AMX/SME)" unit="gflops" description="Matrix-multiply speed through Apple&apos;s Accelerate library, the only way to reach the matrix coprocessor Apple ships but does not expose as instructions. The library uses every core itself, so there is no single-thread row.">
-        <metric name="sgemm" info="Best 32-bit result over a sweep of matrix sizes; the coprocessor is fastest at one particular size.">2448.7874</metric>
-        <metric name="sgemm 8k" info="The 32-bit rate on 8192x8192 matrices -- what large, realistic problems actually sustain.">1680.1603</metric>
-        <metric name="dgemm" info="Best 64-bit result over the same size sweep.">602.8302</metric>
+        <metric name="sgemm" info="Best 32-bit result over a sweep of matrix sizes; the coprocessor is fastest at one particular size.">2307.3630</metric>
+        <metric name="sgemm 8k" info="The 32-bit rate on 8192x8192 matrices -- what large, realistic problems actually sustain.">1668.9524</metric>
+        <metric name="dgemm" info="Best 64-bit result over the same size sweep.">615.8542</metric>
       </test>
       <test name="bnns_matmul" display="BNNS matmul (AMX/SME)" unit="gflops" description="Matrix-multiply speed through Apple&apos;s BNNS library, the only public route to reduced-precision (16-bit) matrix maths on Apple Silicon.">
-        <metric name="fp16" info="16-bit float inputs.">2144.6353</metric>
-        <metric name="bf16" info="bfloat16 inputs, the AI-oriented 16-bit format. On chips with no bf16 hardware the library emulates it, and the rate falls accordingly.">627.0703</metric>
+        <metric name="fp16" info="16-bit float inputs.">2131.7620</metric>
+        <metric name="bf16" info="bfloat16 inputs, the AI-oriented 16-bit format. On chips with no bf16 hardware the library emulates it, and the rate falls accordingly.">762.3469</metric>
         <metric name="int8" info="8-bit whole-number inputs." status="unsupported" reason="BNNS exposes no int8 GEMM (quantized inference layers only)"/>
       </test>
       <test name="smt_scaling" display="SMT scaling (fp32 FMA)" unit="gflops" description="Whether the CPU&apos;s extra hardware threads (SMT, or Intel&apos;s Hyper-Threading) actually add throughput: the same maths kernel run once with one thread per physical core, then again on every thread the chip offers.">
@@ -329,16 +332,16 @@
     </category>
     <category name="int_compute">
       <test name="integer_compute_neon" display="Integer compute (NEON)" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind array indexing, hashing, compression and address math.">
-        <metric name="int ST" info="One thread, running on a single core.">57.4282</metric>
-        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">479.1851</metric>
+        <metric name="int ST" info="One thread, running on a single core.">57.1709</metric>
+        <metric name="int MT" info="Every hardware thread at once -- the whole chip.">479.7259</metric>
       </test>
       <test name="int8_dot_product_compute_neon_dotprod" display="INT8 dot-product compute (NEON DotProd)" unit="gops" description="Peak speed of the 8-bit whole-number dot product, the workhorse instruction of quantized (compressed) neural networks running on the CPU.">
-        <metric name="int8_dp ST" info="One thread, running on a single core.">403.7790</metric>
-        <metric name="int8_dp MT" info="Every hardware thread at once -- the whole chip.">3250.4202</metric>
+        <metric name="int8_dp ST" info="One thread, running on a single core.">402.8450</metric>
+        <metric name="int8_dp MT" info="Every hardware thread at once -- the whole chip.">3255.1262</metric>
       </test>
       <test name="integer_divide_compute" display="Integer divide compute u64" unit="gops" description="How many 64-bit whole-number divisions the CPU sustains per second. No CPU has a vector integer divide, so this is one narrow scalar unit and usually the slowest instruction on the chip.">
-        <metric name="u64 ST" info="One thread, running on a single core.">1.1503</metric>
-        <metric name="u64 MT" info="Every hardware thread at once -- the whole chip.">8.6277</metric>
+        <metric name="u64 ST" info="One thread, running on a single core.">1.1501</metric>
+        <metric name="u64 MT" info="Every hardware thread at once -- the whole chip.">8.6041</metric>
       </test>
       <test name="cpu_matrix_int" display="CPU matrix engine (int8)" unit="gops" description="Peak speed of the CPU&apos;s built-in matrix engine -- Intel AMX tiles or Arm SMMLA/SME -- on 8-bit whole numbers, the format quantized neural networks use.">
         <metric name="matrix_int8 ST" status="unsupported" reason="no CPU int8 matrix engine (AMX / I8MM / SME) on this CPU"/>
@@ -346,75 +349,75 @@
     </category>
     <category name="crypto">
       <test name="aes_encrypt_neon_aes" display="AES-128 encrypt (NEON AES)" unit="gbps" description="How many bytes per second the CPU&apos;s dedicated AES instructions encrypt -- the ceiling for disk encryption and HTTPS traffic.">
-        <metric name="aes ST" info="One thread, running on a single core.">13.0410</metric>
-        <metric name="aes MT" info="Every hardware thread at once -- the whole chip.">104.2145</metric>
+        <metric name="aes ST" info="One thread, running on a single core.">12.9563</metric>
+        <metric name="aes MT" info="Every hardware thread at once -- the whole chip.">105.6653</metric>
       </test>
       <test name="sha256_hash_neon_sha2" display="SHA-256 hash (NEON SHA2)" unit="gbps" description="How many bytes per second the CPU hashes with SHA-256, the fingerprint function behind signatures, integrity checks and git-style content addressing.">
-        <metric name="sha256 ST" info="One thread, running on a single core.">3.1684</metric>
-        <metric name="sha256 MT" info="Every hardware thread at once -- the whole chip.">26.8013</metric>
+        <metric name="sha256 ST" info="One thread, running on a single core.">3.1658</metric>
+        <metric name="sha256 MT" info="Every hardware thread at once -- the whole chip.">26.7941</metric>
       </test>
       <test name="sha512_hash_neon_sha512" display="SHA-512 hash (NEON SHA512)" unit="gbps" description="How many bytes per second the CPU hashes with SHA-512, the wider member of the same family. Only Arm cores have an instruction for it today.">
-        <metric name="sha512 ST" info="One thread, running on a single core.">2.0936</metric>
-        <metric name="sha512 MT" info="Every hardware thread at once -- the whole chip.">17.2976</metric>
+        <metric name="sha512 ST" info="One thread, running on a single core.">2.1012</metric>
+        <metric name="sha512 MT" info="Every hardware thread at once -- the whole chip.">17.3514</metric>
       </test>
       <test name="crc32c_armv8_crc32" display="CRC32-C checksum (ARMv8 CRC32)" unit="gbps" description="How many bytes per second the CPU checksums with CRC32-C, the corruption check storage and network stacks run over every block and packet.">
-        <metric name="crc32c ST" info="One thread, running on a single core.">25.5822</metric>
-        <metric name="crc32c MT" info="Every hardware thread at once -- the whole chip.">217.8804</metric>
+        <metric name="crc32c ST" info="One thread, running on a single core.">25.5262</metric>
+        <metric name="crc32c MT" info="Every hardware thread at once -- the whole chip.">222.2754</metric>
       </test>
     </category>
     <category name="string">
       <test name="string_scan_neon" display="String scan (NEON)" unit="gbps" description="How fast the CPU hunts through memory for one particular byte -- what memchr, strlen and every text search do. The data fits in L1 cache, so this is the scanning machinery, not memory speed.">
-        <metric name="byte_scan ST" info="One thread, running on a single core.">86.5458</metric>
-        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">669.2083</metric>
+        <metric name="byte_scan ST" info="One thread, running on a single core.">89.3559</metric>
+        <metric name="byte_scan MT" info="Every hardware thread at once -- the whole chip.">705.1964</metric>
       </test>
       <test name="utf8_validate_neon" display="UTF-8 validate (NEON)" unit="gbps" description="How fast the CPU checks that text is well-formed UTF-8 -- the first thing every parser, browser and web server does to incoming text. Also run on L1-resident data.">
-        <metric name="utf8 ST" info="One thread, running on a single core.">11.7757</metric>
-        <metric name="utf8 MT" info="Every hardware thread at once -- the whole chip.">95.5829</metric>
+        <metric name="utf8 ST" info="One thread, running on a single core.">11.8001</metric>
+        <metric name="utf8 MT" info="Every hardware thread at once -- the whole chip.">95.5530</metric>
       </test>
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="DRAM bandwidth" unit="gbps" description="How many bytes per second all cores together can move to and from main memory. The arrays are far too big for any cache, so every access goes out to RAM.">
-        <metric name="read" info="Reading one large array straight through, start to end.">124.3088</metric>
-        <metric name="copy" info="Copying one large array into another -- a read and a write for every element.">173.1251</metric>
-        <metric name="triad" info="Scaling one array, adding a second and storing to a third: two reads and a write per element, the hardest of the three.">140.2134</metric>
+        <metric name="read" info="Reading one large array straight through, start to end.">126.0032</metric>
+        <metric name="copy" info="Copying one large array into another -- a read and a write for every element.">175.0577</metric>
+        <metric name="triad" info="Scaling one array, adding a second and storing to a third: two reads and a write per element, the hardest of the three.">141.2837</metric>
       </test>
       <test name="cache_bandwidth" display="Cache bandwidth (read)" unit="gbps" description="How many bytes per second the CPU can read out of each cache, from the tiny fast one next to the core to the big slow one shared by all of them. Each reading uses a working set sized to stay inside the cache it names.">
-        <metric name="L1 ST" info="One thread reading from the small cache inside its own core.">150.7418</metric>
-        <metric name="L1 MT" info="Every core reading from its own L1 at the same time.">1191.7961</metric>
-        <metric name="L2 ST" info="One thread reading from the mid-level cache, the next step out.">83.0452</metric>
-        <metric name="L2 MT" info="Every core reading from L2 at once; where L2 is shared, the data is split between them so it still fits.">685.7316</metric>
-        <metric name="L3 ST" info="One thread reading from the large cache shared by all cores.">84.5409</metric>
-        <metric name="L3 MT" info="Every core reading from that shared cache at once, each taking a slice of it.">693.6918</metric>
+        <metric name="L1 ST" info="One thread reading from the small cache inside its own core.">150.7491</metric>
+        <metric name="L1 MT" info="Every core reading from its own L1 at the same time.">1229.6246</metric>
+        <metric name="L2 ST" info="One thread reading from the mid-level cache, the next step out.">81.8049</metric>
+        <metric name="L2 MT" info="Every core reading from L2 at once; where L2 is shared, the data is split between them so it still fits.">693.9456</metric>
+        <metric name="L3 ST" info="One thread reading from the large cache shared by all cores.">84.5864</metric>
+        <metric name="L3 MT" info="Every core reading from that shared cache at once, each taking a slice of it.">679.9205</metric>
       </test>
       <test name="l1_write_bandwidth" display="L1 bandwidth (write / copy)" unit="gbps" description="How many bytes per second a core can write into its nearest cache, and copy within it. Cores have fewer paths out to memory than in, so writing usually lands below the matching read row.">
-        <metric name="write ST" info="One thread storing new values into its own L1.">93.5733</metric>
-        <metric name="write MT" info="Every core storing into its own L1 at the same time.">237.0759</metric>
-        <metric name="copy ST" info="One thread copying inside L1 -- one read plus one write for every byte moved.">147.7910</metric>
-        <metric name="copy MT" info="Every core copying inside its own L1 at the same time.">719.2390</metric>
+        <metric name="write ST" info="One thread storing new values into its own L1.">94.8916</metric>
+        <metric name="write MT" info="Every core storing into its own L1 at the same time.">246.4164</metric>
+        <metric name="copy ST" info="One thread copying inside L1 -- one read plus one write for every byte moved.">147.7546</metric>
+        <metric name="copy MT" info="Every core copying inside its own L1 at the same time.">638.8712</metric>
       </test>
     </category>
     <category name="latency">
       <test name="memory_latency" display="Memory latency (pointer-chase)" unit="ns" description="How long the core waits for one memory read when it has nothing else to do -- each read&apos;s address comes from the previous read, so the hardware cannot start the next one early.">
-        <metric name="L1" info="Reading from the small cache inside the core.">1.2748</metric>
-        <metric name="L2" info="Reading from the mid-level cache, after an L1 miss.">6.7424</metric>
-        <metric name="L3" info="Reading from the last-level cache shared between cores.">6.2211</metric>
-        <metric name="DRAM" info="Reading from main memory at random -- the worst case.">119.8780</metric>
-        <metric name="DRAM linear" info="Main memory again, but read in address order, so the hardware can fetch ahead -- the best case DRAM gets.">1.5032</metric>
-        <metric name="DRAM x8" info="Eight independent chases at once: the reads overlap instead of waiting in turn, so each costs less.">16.0253</metric>
-        <metric name="DRAM x32" info="Thirty-two chases at once -- deep enough that the core runs out of room for further overlap, so the cost per read stops falling.">4.5043</metric>
-        <metric name="TLB miss" info="The address-translation cost on its own: the data is cached, but every read lands on a different page.">16.1117</metric>
+        <metric name="L1" info="Reading from the small cache inside the core.">1.2754</metric>
+        <metric name="L2" info="Reading from the mid-level cache, after an L1 miss.">6.8912</metric>
+        <metric name="L3" info="Reading from the last-level cache shared between cores.">6.5277</metric>
+        <metric name="DRAM" info="Reading from main memory at random -- the worst case.">119.5805</metric>
+        <metric name="DRAM linear" info="Main memory again, but read in address order, so the hardware can fetch ahead -- the best case DRAM gets.">1.4993</metric>
+        <metric name="DRAM x8" info="Eight independent chases at once: the reads overlap instead of waiting in turn, so each costs less.">15.9616</metric>
+        <metric name="DRAM x32" info="Thirty-two chases at once -- deep enough that the core runs out of room for further overlap, so the cost per read stops falling.">4.5122</metric>
+        <metric name="TLB miss" info="The address-translation cost on its own: the data is cached, but every read lands on a different page.">16.0972</metric>
       </test>
       <test name="atomics" display="Atomic fetch-add latency" unit="ns" description="How long one all-or-nothing counter update takes. This is the operation behind locks, reference counts and every shared data structure, so it sets the cost of coordinating between threads.">
-        <metric name="uncontended ST" info="One thread updating a counter nobody else touches, so it stays in that core&apos;s own cache.">2.1622</metric>
-        <metric name="contended MT" info="Every core fighting over the same counter, which has to be handed from core to core -- the time between completed updates anywhere on the chip.">53.4239</metric>
+        <metric name="uncontended ST" info="One thread updating a counter nobody else touches, so it stays in that core&apos;s own cache.">2.1434</metric>
+        <metric name="contended MT" info="Every core fighting over the same counter, which has to be handed from core to core -- the time between completed updates anywhere on the chip.">64.0897</metric>
       </test>
       <test name="branch_mispredict" display="Branch mispredict penalty" unit="ns" description="What it costs when the CPU guesses the wrong way at an if-statement. The same loop runs over sorted data (easy to guess) and shuffled data (a coin flip), and the difference is the price of a wrong guess.">
-        <metric name="predicted" info="Time per if-statement on sorted data, where the CPU guesses right every time.">0.4625</metric>
-        <metric name="random" info="Time per if-statement on shuffled data, where the CPU is wrong about half the time.">3.2444</metric>
-        <metric name="penalty" info="The extra time one wrong guess costs, worked out from the gap between the other two readings.">5.5638</metric>
+        <metric name="predicted" info="Time per if-statement on sorted data, where the CPU guesses right every time.">0.4628</metric>
+        <metric name="random" info="Time per if-statement on shuffled data, where the CPU is wrong about half the time.">3.2524</metric>
+        <metric name="penalty" info="The extra time one wrong guess costs, worked out from the gap between the other two readings.">5.5791</metric>
       </test>
       <test name="store_forward" display="Store-to-load forwarding" unit="ns" description="How fast the core can read back a value it just wrote, without the write having reached the cache yet.">
-        <metric name="st-&gt;ld ST">0.3182</metric>
+        <metric name="st-&gt;ld ST">0.3186</metric>
       </test>
     </category>
   </run>

--- a/results/Nvidia/GeForce_RTX_5060.xml
+++ b/results/Nvidia/GeForce_RTX_5060.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<clpeak format_version="2" clpeak_version="2.1.2-63-g2f7542b" os="Linux x64">
+<clpeak format_version="2" clpeak_version="2.1.2-69-g940fa86" os="Linux x64">
   <run backend="CUDA" platform="CUDA" device="NVIDIA GeForce RTX 5060" driver="13.3">
     <prop name="Arch" value="sm_120"/>
     <prop name="Toolkit" value="13.3"/>
@@ -7,128 +7,128 @@
     <prop name="VRAM" value="7743 MB"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the GPU&apos;s shader cores on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float">21130.3633</metric>
+        <metric name="float">21118.7148</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on. NVIDIA shader cores reach full speed only on the packed form that does two at a time.">
-        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">21153.0840</metric>
-        <metric name="half2" info="Two values per thread at a time, packed into one instruction.">21185.6484</metric>
+        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">21142.8750</metric>
+        <metric name="half2" info="Two values per thread at a time, packed into one instruction.">21172.7480</metric>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer GeForce cards run these dozens of times slower than 32-bit; the datacenter parts do not.">
-        <metric name="double">335.1401</metric>
+        <metric name="double">333.7519</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the GPU multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses. This is the shader cores, not the tensor cores.">
-        <metric name="mp">18695.0605</metric>
+        <metric name="mp">20699.4414</metric>
       </test>
       <test name="bfloat16_compute" display="BF16 compute bf16xbf16+fp32" unit="gflops" description="Peak speed on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float. Again the shader cores, with the tensor-core figure in the WMMA rows.">
-        <metric name="bf16">20375.8965</metric>
+        <metric name="bf16">20365.7012</metric>
       </test>
       <test name="wmma_fp16" display="WMMA fp16xfp16+fp32 16x16x16" unit="tflops" description="Peak speed of the tensor cores -- dedicated units that multiply whole 16x16 blocks of numbers in one step rather than one value at a time -- on 16-bit inputs with a 32-bit running total. This is the everyday precision of AI work.">
-        <metric name="wmma_fp16">42.5757</metric>
+        <metric name="wmma_fp16">42.5545</metric>
       </test>
       <test name="wmma_fp16_f16" display="FP16 mma.sync m16n8k16+fp16" unit="tflops" description="The same 16-bit tensor-core maths, but keeping the running total in 16 bits too. On GeForce cards the 32-bit-total form is deliberately capped at half rate, so this row is where the full tensor-core speed shows up.">
-        <metric name="fp16_f16acc">83.4591</metric>
+        <metric name="fp16_f16acc">83.4135</metric>
       </test>
       <test name="wmma_bf16" display="WMMA bf16xbf16+fp32 16x16x16" unit="tflops" description="Tensor cores on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float, which makes training far more forgiving.">
-        <metric name="wmma_bf16">42.5726</metric>
+        <metric name="wmma_bf16">42.5527</metric>
       </test>
       <test name="wmma_tf32" display="TF32 mma.sync m16n8k8+fp32" unit="tflops" description="Tensor cores on tf32, NVIDIA&apos;s trimmed-down stand-in for 32-bit float: it keeps the full number range but drops accuracy to fit the tensor cores.">
-        <metric name="wmma_tf32">21.3058</metric>
+        <metric name="wmma_tf32">21.2887</metric>
       </test>
       <test name="wmma_fp64" display="WMMA fp64xfp64+fp64 8x8x4" unit="tflops" description="Tensor cores on full 64-bit numbers, for scientific computing. Only the datacenter parts carry this hardware.">
-        <metric name="wmma_fp64">0.2931</metric>
+        <metric name="wmma_fp64">0.2930</metric>
       </test>
       <test name="wmma_fp8_e4m3" display="FP8(E4M3) mma.sync m16n8k32+fp32" unit="tflops" description="Tensor cores on 8-bit numbers, in the variant that spends its bits on accuracy rather than range. Half the data of 16-bit per value, so it runs at roughly twice the rate.">
-        <metric name="fp8_e4m3">85.1355</metric>
+        <metric name="fp8_e4m3">85.1392</metric>
       </test>
       <test name="wmma_fp8_e5m2" display="FP8(E5M2) mma.sync m16n8k32+fp32" unit="tflops" description="The same 8-bit tensor-core path in the other variant, which spends its bits on range rather than accuracy -- the one that copes with very large and very small values.">
-        <metric name="fp8_e5m2">85.1506</metric>
+        <metric name="fp8_e5m2">85.1239</metric>
       </test>
       <test name="wmma_fp8_f16" display="FP8(E4M3) mma.sync m16n8k32+fp16" unit="tflops" description="The same 8-bit tensor-core maths, but keeping the running total in 16 bits rather than 32. On GeForce cards the 32-bit-total form is deliberately capped at half rate, so this row is where the full 8-bit speed shows up.">
-        <metric name="fp8_e4m3_f16acc">166.8525</metric>
+        <metric name="fp8_e4m3_f16acc">166.7970</metric>
       </test>
       <test name="wmma_fp8_sparse" display="FP8(E4M3) mma.sp 2:4 sparsity m16n8k64+fp32" unit="tflops" description="8-bit numbers with structured sparsity: half the values in each group of four are known to be zero and are skipped, so the hardware does twice the useful work per step.">
-        <metric name="fp8_sparse">169.7355</metric>
+        <metric name="fp8_sparse">169.6529</metric>
       </test>
       <test name="wmma_fp8_sparse_f16" display="FP8(E4M3) mma.sp 2:4 sparsity m16n8k64+fp16" unit="tflops" description="8-bit numbers with both tricks at once: half the values in each group of four are skipped as known zeros, and the running total is kept in 16 bits rather than 32. The fastest arrangement these tensor cores offer for 8-bit.">
-        <metric name="fp8_sparse_f16acc">326.2036</metric>
+        <metric name="fp8_sparse_f16acc">326.1041</metric>
       </test>
       <test name="wmma_fp4_e2m1" display="FP4(E2M1) mma.sync m16n8k32+fp32" unit="tflops" description="Tensor cores on 4-bit numbers, the narrowest format the hardware handles. Blackwell and newer only.">
-        <metric name="fp4_e2m1">85.1571</metric>
+        <metric name="fp4_e2m1">85.1420</metric>
       </test>
       <test name="wmma_mxf4_e2m1" display="MXFP4(E2M1) mma.sync m16n8k64+fp32" unit="tflops" description="4-bit numbers with a shared scale factor per block of 32, the open MX format. The scale is what makes 4 bits usable for real models rather than a curiosity.">
-        <metric name="mxf4_e2m1">326.0426</metric>
+        <metric name="mxf4_e2m1">325.8528</metric>
       </test>
       <test name="wmma_nvf4_e2m1" display="NVFP4(E2M1) mma.sync m16n8k64+fp32" unit="tflops" description="NVIDIA&apos;s own 4-bit block format, with a finer scale factor shared by every 16 values instead of every 32 -- more accurate than MX at the same width.">
-        <metric name="nvf4_e2m1">328.4947</metric>
+        <metric name="nvf4_e2m1">328.3607</metric>
       </test>
       <test name="wmma_mxf4_sparse" display="MXFP4 mma.sp 2:4 sparsity m16n8k128+fp32" unit="tflops" description="The MX 4-bit path with structured sparsity: half the values in each group of four are known to be zero and are skipped, so the hardware does twice the useful work per step.">
-        <metric name="mxf4_sparse">633.1989</metric>
+        <metric name="mxf4_sparse">630.7183</metric>
       </test>
       <test name="wmma_nvf4_sparse" display="NVFP4 mma.sp 2:4 sparsity m16n8k128+fp32" unit="tflops" description="NVIDIA&apos;s 4-bit block format with the same skip-the-zeros trick -- the fastest arrangement these tensor cores offer.">
-        <metric name="nvf4_sparse">633.0802</metric>
+        <metric name="nvf4_sparse">630.7552</metric>
       </test>
       <test name="cublas-fp" display="cuBLASLt GEMM peak" unit="tflops" description="Matrix-multiply speed through NVIDIA&apos;s own tuned library, on a large square problem. Where the WMMA rows show what the tensor cores can do in principle, this shows what shipping code reaches on the operation most AI work is built from.">
-        <metric name="fp32" info="Full 32-bit precision, on the ordinary shader cores rather than the tensor cores.">14.8679</metric>
-        <metric name="fp64" info="Full 64-bit precision, for scientific computing. Consumer cards run this far slower than the datacenter parts.">0.2922</metric>
-        <metric name="tf32" info="32-bit numbers in and out, but rounded internally to a shorter form so the tensor cores can take them.">20.6230</metric>
-        <metric name="fp16" info="16-bit inputs and totals -- the everyday precision of AI inference, and usually the fastest row here.">79.1550</metric>
-        <metric name="bf16" info="bfloat16 inputs with 32-bit totals -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float.">40.8634</metric>
-        <metric name="fp8_e4m3" info="8-bit inputs, in the variant that spends its bits on accuracy rather than range.">153.4875</metric>
-        <metric name="fp8_e5m2" info="8-bit inputs including the variant that spends its bits on range rather than accuracy -- the usual choice for inference.">158.3810</metric>
+        <metric name="fp32" info="Full 32-bit precision, on the ordinary shader cores rather than the tensor cores.">14.8551</metric>
+        <metric name="fp64" info="Full 64-bit precision, for scientific computing. Consumer cards run this far slower than the datacenter parts.">0.2921</metric>
+        <metric name="tf32" info="32-bit numbers in and out, but rounded internally to a shorter form so the tensor cores can take them.">20.8022</metric>
+        <metric name="fp16" info="16-bit inputs and totals -- the everyday precision of AI inference, and usually the fastest row here.">79.1421</metric>
+        <metric name="bf16" info="bfloat16 inputs with 32-bit totals -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float.">41.9411</metric>
+        <metric name="fp8_e4m3" info="8-bit inputs, in the variant that spends its bits on accuracy rather than range.">153.1004</metric>
+        <metric name="fp8_e5m2" info="8-bit inputs including the variant that spends its bits on range rather than accuracy -- the usual choice for inference.">158.3339</metric>
         <metric name="mxf4_e2m1" info="4-bit inputs with a shared scale factor per block of 32, the open MX format. The scale is what makes 4 bits usable for real models." status="unsupported" reason="unsupported on sm_120"/>
-        <metric name="nvf4_e2m1" info="NVIDIA&apos;s own 4-bit block format, with a finer scale shared by every 16 values instead of every 32 -- more accurate than MX at the same width.">300.4289</metric>
+        <metric name="nvf4_e2m1" info="NVIDIA&apos;s own 4-bit block format, with a finer scale shared by every 16 values instead of every 32 -- more accurate than MX at the same width.">300.3102</metric>
       </test>
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute (32-bit IMAD)" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which shaders do alongside their fractional maths.">
-        <metric name="int">10548.1748</metric>
+        <metric name="int">10540.8135</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute (__dp4a)" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the shader-core path for quantized (compressed) neural networks.">
-        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">41950.4609</metric>
-        <metric name="int8_dp2" info="Two independent chains, so the GPU has a second dot product to get on with while the first is still finishing.">41889.4531</metric>
-        <metric name="int8_dp4" info="Four independent chains.">41798.9219</metric>
-        <metric name="int8_dp8" info="Eight independent chains. Where this stops improving on four, the hardware itself is the limit, not the waiting.">41712.1406</metric>
+        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">41922.6836</metric>
+        <metric name="int8_dp2" info="Two independent chains, so the GPU has a second dot product to get on with while the first is still finishing.">41864.8711</metric>
+        <metric name="int8_dp4" info="Four independent chains.">41799.0664</metric>
+        <metric name="int8_dp8" info="Eight independent chains. Where this stops improving on four, the hardware itself is the limit, not the waiting.">41691.9883</metric>
       </test>
       <test name="wmma_int8" display="WMMA int8xint8+int32 16x16x16" unit="tops" description="Tensor cores on 8-bit whole numbers with a 32-bit running total -- the format quantized neural networks use when they are squeezed down to run fast on cheaper hardware.">
-        <metric name="wmma_int8">84.3948</metric>
+        <metric name="wmma_int8">84.3770</metric>
       </test>
       <test name="wmma_int8_k32" display="INT8 mma.sync m16n8k32+int32" unit="tops" description="The same 8-bit whole-number maths on NVIDIA&apos;s own native tile shape rather than the portable one, which the hardware feeds more efficiently.">
-        <metric name="int8_k32">164.8455</metric>
+        <metric name="int8_k32">164.7991</metric>
       </test>
       <test name="wmma_int8_sparse" display="INT8 mma.sp 2:4 sparsity m16n8k64+int32" unit="tops" description="8-bit whole numbers with structured sparsity: half the values in each group of four are known to be zero and are skipped, so the hardware does twice the useful work per step.">
-        <metric name="int8_sparse">327.3679</metric>
+        <metric name="int8_sparse">327.2349</metric>
       </test>
       <test name="wmma_int4" display="INT4 mma.sync m8n8k32+int32" unit="tops" description="Tensor cores on 4-bit whole numbers. Turing through Ada only -- NVIDIA dropped the integer 4-bit path afterwards in favour of the 4-bit float formats above.">
         <metric name="int4" status="unsupported" reason="INT4 mma.sync requires sm_75..sm_89 (Turing/Ampere/Ada)! Skipped"/>
       </test>
       <test name="cublas-int" display="cuBLASLt GEMM peak" unit="tops" description="The same tuned-library matrix multiply on whole-number formats, which is how a quantized (compressed) model actually runs.">
-        <metric name="int8" info="8-bit whole numbers with 32-bit totals -- the format quantized neural networks use.">133.2604</metric>
+        <metric name="int8" info="8-bit whole numbers with 32-bit totals -- the format quantized neural networks use.">133.2210</metric>
         <metric name="int4" info="4-bit whole numbers. The library may refuse this even where the hardware claims it." status="unsupported" reason="unsupported on sm_120"/>
       </test>
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the GPU can stream out of its own memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">392.9116</metric>
-        <metric name="float2" info="Two values per thread at a time, packed into one instruction.">411.0123</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">419.6685</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">394.7248</metric>
+        <metric name="float2" info="Two values per thread at a time, packed into one instruction.">411.8218</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">419.6251</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the GPU moves through shared memory -- the small on-chip scratchpad a block of threads passes data through, which never goes out to the card&apos;s main memory.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4428.7041</metric>
-        <metric name="float2" info="Two values per thread at a time, packed into one instruction.">8129.4590</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">9140.8779</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4427.6460</metric>
+        <metric name="float2" info="Two values per thread at a time, packed into one instruction.">8128.2554</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">9138.7207</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the GPU reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">419.0422</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">418.9401</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the computer&apos;s own memory and the card&apos;s, over the PCIe link. That link is far narrower than either side&apos;s own memory, which is what makes moving data to the GPU worth avoiding. Both readings use pinned host memory, the fast path.">
-        <metric name="h2d_pinned" info="Host to device: sending data up to the card.">13.9112</metric>
-        <metric name="d2h_pinned" info="Device to host: reading results back down. Often a little slower than the other direction.">14.3063</metric>
+        <metric name="h2d_pinned" info="Host to device: sending data up to the card.">13.9092</metric>
+        <metric name="d2h_pinned" info="Device to host: reading results back down. Often a little slower than the other direction.">14.3062</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the GPU to do anything at all, measured with a kernel that does no work. It is what small, frequent GPU jobs pay before any of their own work begins.">
         <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the GPU starts running it. CUDA exposes no clock the host and GPU share, so this is reported on the other backends but not here." status="unsupported" reason="Not measurable via CUDA driver API"/>
-        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">6.6790</metric>
+        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">6.1237</metric>
       </test>
     </category>
   </run>
@@ -138,84 +138,87 @@
     <prop name="Compute units" value="30"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">20837.8496</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">20926.1406</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">21055.2324</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">20826.1035</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">20906.5801</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">21022.1328</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute fp16xfp16+fp16" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on. Both the inputs and the running total stay 16-bit here.">
-        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">20925.6797</metric>
-        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">21089.0645</metric>
-        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">21120.3438</metric>
+        <metric name="half" info="One value per thread at a time -- the plain, unvectorised case.">20924.6172</metric>
+        <metric name="half2" info="Two values per thread at a time, as one 2-wide vector.">21092.0645</metric>
+        <metric name="half4" info="Four values per thread at a time, as one 4-wide vector.">21112.6953</metric>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts deliberately run these many times slower than 32-bit.">
-        <metric name="double" info="One value per thread at a time -- the plain, unvectorised case.">330.5248</metric>
-        <metric name="double2" info="Two values per thread at a time, as one 2-wide vector.">327.8163</metric>
-        <metric name="double4" info="Four values per thread at a time, as one 4-wide vector.">321.1844</metric>
+        <metric name="double" info="One value per thread at a time -- the plain, unvectorised case.">330.4647</metric>
+        <metric name="double2" info="Two values per thread at a time, as one 2-wide vector.">327.7941</metric>
+        <metric name="double4" info="Four values per thread at a time, as one 4-wide vector.">321.2438</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
-        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">18497.9961</metric>
-        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">15678.2012</metric>
-        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">18040.7812</metric>
+        <metric name="mp" info="One value per thread at a time -- the plain, unvectorised case.">20482.9297</metric>
+        <metric name="mp2" info="Two values per thread at a time, as one 2-wide vector.">20219.9355</metric>
+        <metric name="mp4" info="Four values per thread at a time, as one 4-wide vector.">20415.4922</metric>
       </test>
       <test name="bfloat16_compute" display="BF16 compute bf16xbf16+fp32" unit="gflops" description="Peak speed on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the same number range as a full float. The running total is kept in 32 bits.">
-        <metric name="bf16" info="One value per thread at a time -- the plain, unvectorised case.">19651.1523</metric>
-        <metric name="bf16_2" info="Two values per thread at a time, as one 2-wide vector.">18080.2422</metric>
-        <metric name="bf16_4" info="Four values per thread at a time, as one 4-wide vector.">19206.1973</metric>
+        <metric name="bf16" info="One value per thread at a time -- the plain, unvectorised case.">19589.0176</metric>
+        <metric name="bf16_2" info="Two values per thread at a time, as one 2-wide vector.">18062.4102</metric>
+        <metric name="bf16_4" info="Four values per thread at a time, as one 4-wide vector.">19208.7559</metric>
       </test>
       <test name="coopmat_fp32" display="Cooperative-matrix fp32xfp32+fp32" unit="tflops" description="Peak speed of the device&apos;s matrix engine (its tensor cores) on full 32-bit numbers. These units multiply whole small blocks of numbers in one step instead of one value at a time.">
         <metric name="coopmat_fp32" status="unsupported" reason="No fp32xfp32+fp32 coopmat property! Skipped"/>
       </test>
-      <test name="coopmat_fp16" display="Cooperative-matrix fp16xfp16+fp32 16x16x16" unit="tflops" description="The matrix engine on 16-bit inputs with a 32-bit running total -- the everyday precision of AI inference, and usually the fastest widely-supported row here.">
-        <metric name="coopmat_fp16">42.4530</metric>
+      <test name="coopmat_fp16" display="Cooperative-matrix fp16xfp16+fp32 16x16x16" unit="tflops" description="The matrix engine on 16-bit inputs with a 32-bit running total -- the everyday precision of AI inference, and the widest-supported row here. Keeping the total at 32 bits costs accuracy nothing and, on consumer graphics cards, costs half the speed: see the 16-bit-total row below.">
+        <metric name="coopmat_fp16">42.4466</metric>
+      </test>
+      <test name="coopmat_fp16_f16acc" display="Cooperative-matrix fp16xfp16+fp16 16x16x16" unit="tflops" description="The matrix engine on 16-bit inputs with the running total also kept at 16 bits. Consumer graphics cards run this at twice the rate of the 32-bit total above, which is why a card&apos;s headline AI figure is usually this one; server parts run both alike.">
+        <metric name="coopmat_fp16_f16acc">84.7759</metric>
       </test>
       <test name="coopmat_bf16" display="Cooperative-matrix bf16xbf16+fp32 16x16x16" unit="tflops" description="The matrix engine on bfloat16 -- 16 bits arranged for AI work, trading digits of accuracy for the number range of a full float, which makes training far more forgiving.">
-        <metric name="coopmat_bf16">42.4338</metric>
+        <metric name="coopmat_bf16">42.4106</metric>
       </test>
       <test name="coopmat_fp8_e4m3" display="Cooperative-matrix fp8(E4M3)xfp8(E4M3)+fp32 16x16x32" unit="tflops" description="The matrix engine on 8-bit numbers, in the variant that spends its bits on accuracy rather than range. Half the data of fp16 per value, so the newest hardware runs it at roughly twice the rate.">
-        <metric name="coopmat_fp8_e4m3">84.7894</metric>
+        <metric name="coopmat_fp8_e4m3">84.7855</metric>
       </test>
       <test name="coopmat_fp8_e5m2" display="Cooperative-matrix fp8(E5M2)xfp8(E5M2)+fp32 16x16x32" unit="tflops" description="The same 8-bit matrix path in the other variant, which spends its bits on range rather than accuracy -- the one that copes with very large and very small values.">
-        <metric name="coopmat_fp8_e5m2">84.7851</metric>
+        <metric name="coopmat_fp8_e5m2">84.7346</metric>
       </test>
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute int32" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per thread at a time -- the plain, unvectorised case.">10554.2168</metric>
-        <metric name="int2" info="Two values per thread at a time, as one 2-wide vector.">10516.5605</metric>
-        <metric name="int4" info="Four values per thread at a time, as one 4-wide vector.">10384.7236</metric>
+        <metric name="int" info="One value per thread at a time -- the plain, unvectorised case.">10551.0391</metric>
+        <metric name="int2" info="Two values per thread at a time, as one 2-wide vector.">10509.9521</metric>
+        <metric name="int4" info="Four values per thread at a time, as one 4-wide vector.">10368.4912</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
-        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">33342.1211</metric>
-        <metric name="int8_dp2" info="Two independent chains, so the device has a second dot product to get on with while the first is still finishing.">29807.1602</metric>
-        <metric name="int8_dp4" info="Four independent chains -- usually enough to keep the dot-product hardware busy with no waiting at all.">31894.2930</metric>
+        <metric name="int8_dp" info="One chain of dot products, each waiting on the one before it.">33343.8125</metric>
+        <metric name="int8_dp2" info="Two independent chains, so the device has a second dot product to get on with while the first is still finishing.">29799.9062</metric>
+        <metric name="int8_dp4" info="Four independent chains -- usually enough to keep the dot-product hardware busy with no waiting at all.">31908.2227</metric>
       </test>
       <test name="coopmat_int8" display="Cooperative-matrix int8xint8+int32 16x16x32" unit="tops" description="The matrix engine on 8-bit whole numbers with a 32-bit running total -- the format quantized neural networks use when they are squeezed down to run fast on cheaper hardware.">
-        <metric name="coopmat_int8">168.1610</metric>
+        <metric name="coopmat_int8">167.9805</metric>
       </test>
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">397.4358</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">417.0078</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">425.0872</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">397.2172</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">416.2584</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">424.9784</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through shared local memory -- the small on-chip scratchpad a group of threads passes data through, which never goes out to main memory.">
-        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4402.9980</metric>
-        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">7997.8242</metric>
-        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">9128.0117</metric>
+        <metric name="float" info="One value per thread at a time -- the plain, unvectorised case.">4404.1089</metric>
+        <metric name="float2" info="Two values per thread at a time, as one 2-wide vector.">7995.8838</metric>
+        <metric name="float4" info="Four values per thread at a time, as one 4-wide vector.">9121.4062</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">424.9507</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">424.4699</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is usually far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding.">
-        <metric name="h2d" info="Host to device: sending data across to the device.">12.6489</metric>
-        <metric name="d2h" info="Device to host: reading results back. Often slower than the other direction.">13.1927</metric>
+        <metric name="h2d" info="Host to device: sending data across to the device.">12.6538</metric>
+        <metric name="d2h" info="Device to host: reading results back. Often slower than the other direction.">13.1926</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all, measured with a shader that does no work. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it.">5.5328</metric>
-        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">40.3125</metric>
+        <metric name="dispatch" info="One way only: from the moment the host submits the work to the moment the device starts running it.">5.3237</metric>
+        <metric name="roundtrip" info="The full round trip -- submit, run, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">39.9054</metric>
       </test>
     </category>
   </run>
@@ -224,11 +227,11 @@
     <prop name="Clock frequency" value="2512 MHz"/>
     <category name="fp_compute">
       <test name="single_precision_compute" display="Single-precision compute" unit="gflops" description="Peak arithmetic speed of the device&apos;s compute units on 32-bit fractional numbers -- the ordinary float type. Nothing touches memory, so only the arithmetic units limit the rate.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">20472.7441</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">20689.8301</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">20760.6699</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">20843.9941</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">20681.8594</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">20470.1152</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">20686.6348</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">20760.2520</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">20842.5254</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">20681.4863</metric>
       </test>
       <test name="half_precision_compute" display="Half-precision compute" unit="gflops" description="Peak arithmetic speed on 16-bit fractional numbers -- half the size of a normal float, and what graphics and on-device AI mostly run on.">
         <metric name="half" status="unsupported" reason="No half precision support"/>
@@ -238,11 +241,11 @@
         <metric name="half16" status="unsupported" reason="No half precision support"/>
       </test>
       <test name="double_precision_compute" display="Double-precision compute" unit="gflops" description="Peak arithmetic speed on 64-bit fractional numbers, the high-accuracy type scientific computing relies on. Consumer graphics parts deliberately run these many times slower than 32-bit.">
-        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">332.5974</metric>
-        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">332.1831</metric>
-        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">332.8558</metric>
-        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">331.2280</metric>
-        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">328.0938</metric>
+        <metric name="double" info="One value per work-item at a time -- the plain, unvectorised case.">332.5672</metric>
+        <metric name="double2" info="Two values per work-item at a time, as one 2-wide vector.">332.1584</metric>
+        <metric name="double4" info="Four values per work-item at a time, as one 4-wide vector.">331.2948</metric>
+        <metric name="double8" info="Eight values per work-item at a time, as one 8-wide vector.">329.6383</metric>
+        <metric name="double16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">326.4758</metric>
       </test>
       <test name="mixed_precision_compute" display="Mixed-precision compute fp16xfp16+fp32" unit="gflops" description="Peak speed when the device multiplies 16-bit numbers but keeps the running total in 32 bits -- the accuracy-preserving pattern AI code uses.">
         <metric name="mp" status="unsupported" reason="No half precision support"/>
@@ -254,32 +257,32 @@
     </category>
     <category name="int_compute">
       <test name="integer_compute" display="Integer compute" unit="gops" description="Peak speed on 32-bit whole numbers -- the arithmetic behind indexing, addressing and bit manipulation, which kernels do alongside their fractional maths.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">10524.2217</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">10530.4492</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">10327.5459</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">10349.7344</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">10309.7061</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">10521.8076</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">10527.1758</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">10334.7871</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">10347.4277</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">10310.1621</metric>
       </test>
       <test name="integer_compute_fast" display="Integer compute Fast 24bit" unit="gops" description="The same integer maths restricted to 24-bit values, which some devices multiply on their faster floating-point hardware instead. Where this beats the plain integer row, the full 32-bit multiply is the slower path.">
-        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">10353.3936</metric>
-        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">10362.1152</metric>
-        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">10327.5439</metric>
-        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">10280.2998</metric>
-        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">10186.9336</metric>
+        <metric name="int" info="One value per work-item at a time -- the plain, unvectorised case.">10463.6201</metric>
+        <metric name="int2" info="Two values per work-item at a time, as one 2-wide vector.">10471.6406</metric>
+        <metric name="int4" info="Four values per work-item at a time, as one 4-wide vector.">10344.7461</metric>
+        <metric name="int8" info="Eight values per work-item at a time, as one 8-wide vector.">10280.3906</metric>
+        <metric name="int16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">10183.1602</metric>
       </test>
       <test name="integer_compute_char" display="Integer char (8bit) compute" unit="gops" description="Peak speed on 8-bit whole numbers, the smallest integer type -- worth knowing because image and quantized-AI work is full of them.">
-        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">10059.0889</metric>
-        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">10109.1289</metric>
-        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">9976.5654</metric>
-        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">9046.3848</metric>
-        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">10093.6064</metric>
+        <metric name="char" info="One value per work-item at a time -- the plain, unvectorised case.">10056.8203</metric>
+        <metric name="char2" info="Two values per work-item at a time, as one 2-wide vector.">10110.7451</metric>
+        <metric name="char4" info="Four values per work-item at a time, as one 4-wide vector.">9953.4844</metric>
+        <metric name="char8" info="Eight values per work-item at a time, as one 8-wide vector.">9038.7744</metric>
+        <metric name="char16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">10092.9766</metric>
       </test>
       <test name="integer_compute_short" display="Integer short (16bit) compute" unit="gops" description="Peak speed on 16-bit whole numbers -- the middle size, between the 8-bit and 32-bit rows.">
-        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">10023.7812</metric>
-        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">9908.3555</metric>
-        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">9883.8340</metric>
-        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">8952.0049</metric>
-        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">9242.7070</metric>
+        <metric name="short" info="One value per work-item at a time -- the plain, unvectorised case.">10021.9414</metric>
+        <metric name="short2" info="Two values per work-item at a time, as one 2-wide vector.">9908.2363</metric>
+        <metric name="short4" info="Four values per work-item at a time, as one 4-wide vector.">9873.5566</metric>
+        <metric name="short8" info="Eight values per work-item at a time, as one 8-wide vector.">8940.9121</metric>
+        <metric name="short16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">9240.9268</metric>
       </test>
       <test name="integer_compute_int8_dp" display="INT8 dot-product compute" unit="gops" description="Peak speed of the 8-bit dot-product instruction, which multiplies four pairs of small whole numbers and sums them in one step -- the workhorse of quantized (compressed) neural networks.">
         <metric name="int8_dp" status="unsupported" reason="cl_khr_integer_dot_product not supported"/>
@@ -291,30 +294,30 @@
     </category>
     <category name="bandwidth">
       <test name="global_memory_bandwidth" display="Global memory bandwidth" unit="gbps" description="How many bytes per second the device can stream out of its main memory, reading a buffer far too large to cache. Each reading fetches a different number of values per instruction, since wider fetches usually pull more through before the memory system saturates.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">394.1376</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">410.5687</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">419.6234</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">422.8071</metric>
-        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">424.3091</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">392.8643</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">410.0974</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">419.6040</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">422.8341</metric>
+        <metric name="float16" info="Sixteen values per work-item at a time, the widest vector OpenCL offers.">424.3850</metric>
       </test>
       <test name="local_memory_bandwidth" display="Local memory bandwidth" unit="gbps" description="How many bytes per second the device moves through local memory -- the small on-chip scratchpad a group of work-items passes data through, which never goes out to main memory.">
-        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">4384.7285</metric>
-        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">7952.7329</metric>
-        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">9132.2939</metric>
-        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">5015.8608</metric>
+        <metric name="float" info="One value per work-item at a time -- the plain, unvectorised case.">4382.7471</metric>
+        <metric name="float2" info="Two values per work-item at a time, as one 2-wide vector.">7950.0845</metric>
+        <metric name="float4" info="Four values per work-item at a time, as one 4-wide vector.">9129.1543</metric>
+        <metric name="float8" info="Eight values per work-item at a time, as one 8-wide vector.">5014.4634</metric>
       </test>
       <test name="image_memory_bandwidth" display="Image memory bandwidth" unit="gbps" description="How many bytes per second the device reads through its texture units, which take a different path to memory than plain buffer reads. Each pixel of the image is read exactly once, so caching cannot flatter the number.">
-        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">418.9454</metric>
+        <metric name="float4" info="Each fetch returns one whole pixel -- four 32-bit colour values, 16 bytes.">418.9575</metric>
       </test>
       <test name="transfer_bandwidth" display="Transfer bandwidth" unit="gbps" description="How fast data crosses between the host&apos;s memory and the device&apos;s. On a discrete card that means the PCIe link, which is far narrower than either side&apos;s own memory and is what makes moving data to the device worth avoiding; where the two share one pool of memory the numbers are much higher. Both readings use pinned host memory, the fast path.">
-        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">13.9101</metric>
-        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">14.3050</metric>
+        <metric name="h2d_pinned" info="Host to device: sending data across to the device.">13.9079</metric>
+        <metric name="d2h_pinned" info="Device to host: reading results back. Often a little slower than the other direction.">14.3049</metric>
       </test>
     </category>
     <category name="latency">
       <test name="kernel_launch_latency" display="Kernel launch latency" unit="us" description="The overhead of asking the device to do anything at all. It is what small, frequent jobs pay before any of their own work begins.">
-        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">6.3284</metric>
-        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">16.0854</metric>
+        <metric name="dispatch" info="One way only: from the moment the host queues the work to the moment the device starts running it.">6.3312</metric>
+        <metric name="roundtrip" info="The full round trip -- queue it, run it, and hear back that it finished. This is what the host waits for if it has nothing else to get on with.">15.4142</metric>
       </test>
     </category>
   </run>

--- a/src/cuda/cuda_kernels/compute_mp.cu
+++ b/src/cuda/cuda_kernels/compute_mp.cu
@@ -17,6 +17,8 @@
 
 #define MAD_4(x, c)  x = fmaf(x, x, c); x = fmaf(x, x, c); x = fmaf(x, x, c); x = fmaf(x, x, c);
 #define MAD_16(x, c) MAD_4(x, c) MAD_4(x, c) MAD_4(x, c) MAD_4(x, c)
+#define MAD_128(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) \
+                      MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c)
 
 extern "C" __global__ void compute_mp(float *out, float A)
 {
@@ -26,9 +28,9 @@ extern "C" __global__ void compute_mp(float *out, float A)
     float c = __half2float(__float2half((float)threadIdx.x));
 
     #pragma unroll
-    for (int i = 0; i < 128; i++)
+    for (int i = 0; i < 16; i++)
     {
-        MAD_16(x, c)
+        MAD_128(x, c)
         x = __half2float(__float2half(x));
     }
 

--- a/src/metal/mtl_kernels/compute_mp.metal
+++ b/src/metal/mtl_kernels/compute_mp.metal
@@ -13,6 +13,8 @@ using namespace metal;
 
 #define MAD_4(x, c)  x = fma(x, x, c); x = fma(x, x, c); x = fma(x, x, c); x = fma(x, x, c);
 #define MAD_16(x, c) MAD_4(x, c) MAD_4(x, c) MAD_4(x, c) MAD_4(x, c)
+#define MAD_128(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) \
+                      MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c)
 
 kernel void compute_mp(device float* out [[buffer(0)]],
                        constant float& A [[buffer(1)]],
@@ -22,9 +24,9 @@ kernel void compute_mp(device float* out [[buffer(0)]],
     float x = (float)((half)A);
     float c = (float)((half)lid);
 
-    for (int i = 0; i < 128; i++)
+    for (int i = 0; i < 16; i++)
     {
-        MAD_16(x, c)
+        MAD_128(x, c)
         x = (float)((half)x);
     }
 
@@ -32,7 +34,7 @@ kernel void compute_mp(device float* out [[buffer(0)]],
 }
 
 // float2 accumulator, half2 cast per outer iter.
-// 64 outer * 16 fmas * 4 ops = 4096 ops/thread.
+// 8 outer * 128 fmas * 4 ops = 4096 ops/thread.
 kernel void compute_mp2(device float* out [[buffer(0)]],
                         constant float& A [[buffer(1)]],
                         uint tid [[thread_position_in_grid]],
@@ -41,9 +43,9 @@ kernel void compute_mp2(device float* out [[buffer(0)]],
     float2 x = float2((float)((half)A),         (float)((half)(A + 1.0f)));
     float2 c = float2((float)((half)lid),       (float)((half)(lid + 1u)));
 
-    for (int i = 0; i < 64; i++)
+    for (int i = 0; i < 8; i++)
     {
-        MAD_16(x, c)
+        MAD_128(x, c)
         x = float2((float)(half)x.x, (float)(half)x.y);
     }
 
@@ -51,7 +53,7 @@ kernel void compute_mp2(device float* out [[buffer(0)]],
 }
 
 // float4 accumulator, half4 cast per outer iter.
-// 32 outer * 16 fmas * 8 ops = 4096 ops/thread.
+// 4 outer * 128 fmas * 8 ops = 4096 ops/thread.
 kernel void compute_mp4(device float* out [[buffer(0)]],
                         constant float& A [[buffer(1)]],
                         uint tid [[thread_position_in_grid]],
@@ -66,9 +68,9 @@ kernel void compute_mp4(device float* out [[buffer(0)]],
                       (float)((half)(lid + 2u)),
                       (float)((half)(lid + 3u)));
 
-    for (int i = 0; i < 32; i++)
+    for (int i = 0; i < 4; i++)
     {
-        MAD_16(x, c)
+        MAD_128(x, c)
         half4 hx = half4(x);
         x = float4(hx);
     }

--- a/src/oneapi/compute_float.cpp
+++ b/src/oneapi/compute_float.cpp
@@ -46,13 +46,19 @@ float    computeGflops(uint64_t totalThreads, uint32_t workPerWI, float meanUs,
 template <int W> struct AffineChains { static constexpr int N = (W == 1) ? 4 : (W == 2) ? 2 : 1; };
 
 // Four-chain affine, for the families whose accumulator round-trips through a
-// narrow type once per outer iteration (mp, bf16).  Four chains cost four
-// conversions per 16 chain instructions against the squaring build's one, but
-// both report the same op budget, so the extra conversions can only understate
-// the affine reading -- never inflate it -- and the caller takes the maximum.
-// The chains earn their keep: with one chain, mp on an Intel CPU runtime
-// measured 373.1 against 373.8, a dead wash, while the four-chain float path
-// on the same device went 396 -> 1552 GFLOPS.
+// narrow type once per outer iteration (mp, bf16).  The chains earn their keep:
+// with one chain, mp on an Intel CPU runtime measured 373.1 against 373.8, a
+// dead wash, while the four-chain float path on the same device went 396 ->
+// 1552 GFLOPS.
+//
+// Four chains do cost four conversions per round against the squaring build's
+// one, which is why both families run a 128-instruction inner loop rather than
+// MAD_16.  Amortised over 16 that was 25% uncounted instruction overhead, and
+// on Alchemist it is not a shape you can decline -- the squaring build, which
+// needs only one conversion, is the one the three-distinct-source rule halves
+// there.  An Arc A380 read mp at 2.78 TFLOPS against 4.89 for fp32 (57%) at
+// MAD_16, where an RTX 5060, free to take the squaring build, sat at 88%.
+// Over 128 the same four conversions cost ~3%.
 #define MAD_G_AFF4(a, b)     x0 = sycl::fma(a, x0, b); x1 = sycl::fma(a, x1, b); \
                              x2 = sycl::fma(a, x2, b); x3 = sycl::fma(a, x3, b);
 #define MAD_16_AFF4(a, b)    MAD_G_AFF4(a, b) MAD_G_AFF4(a, b) \
@@ -353,8 +359,10 @@ int OneapiPeak::runComputeMP(OneapiDevice &dev, benchmark_config_t &cfg)
           float x = (float)(sycl::half)A;
           float c = (float)(sycl::half)(float)it.get_local_id(0);
           #pragma unroll 1
-          for (int i = 0; i < 128; i++) {
-            MAD_16(x, c)
+          for (int i = 0; i < 16; i++) {
+            // MAD_128 = 8 * MAD_16 = 256 ops
+            MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c)
+            MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c)
             x = (float)(sycl::half)x;
           }
           out[it.get_global_id(0)] = x;
@@ -372,8 +380,10 @@ int OneapiPeak::runComputeMP(OneapiDevice &dev, benchmark_config_t &cfg)
           float x0 = (float)(sycl::half)A;
           float x1 = x0 + 1.0f, x2 = x0 + 2.0f, x3 = x0 + 3.0f;
           #pragma unroll 1
-          for (int i = 0; i < 128; i++) {
-            MAD_16_AFF4(a, b)
+          for (int i = 0; i < 16; i++) {
+            // MAD_128 = 8 * MAD_16_AFF4 = 256 ops
+            MAD_16_AFF4(a, b) MAD_16_AFF4(a, b) MAD_16_AFF4(a, b) MAD_16_AFF4(a, b)
+            MAD_16_AFF4(a, b) MAD_16_AFF4(a, b) MAD_16_AFF4(a, b) MAD_16_AFF4(a, b)
             x0 = (float)(sycl::half)x0; x1 = (float)(sycl::half)x1;
             x2 = (float)(sycl::half)x2; x3 = (float)(sycl::half)x3;
           }

--- a/src/opencl/kernels/compute_mp_kernels.cl
+++ b/src/opencl/kernels/compute_mp_kernels.cl
@@ -4,204 +4,202 @@ MSTRINGIFY(
 // Dominant arithmetic path in LLM training/prefill -- distinct from
 // compute_hp (fp16 accumulator).
 //
-// Each MAD_4 issues 4 mixed-precision multiply-accumulates:
-//   a = convert_floatN(x) * convert_floatN(x) + a;
-// and writes a back into x via an fp16 downcast, so the compiler can't CSE
-// (float)x*(float)x across iterations. The downcast is ~1 cycle on every
-// vendor we care about and does not distort the FMA measurement meaningfully.
+// The chain is carried in fp32 and round-trips through fp16 once per MAD_128
+// round, not once per MAC.  On shader cores fp16xfp16+fp32 lowers to an fp32
+// FMA anyway, so the inner loop is the fp32 chain and the narrowing is what
+// puts the fp16 type in the data path -- the same structure the CUDA, ROCm,
+// Metal, Vulkan and oneAPI mp kernels use.
 //
-// One live chain per lane (the fp32 accumulator a, with x as its fp16
-// shadow), matching the MAD chain rules in include/common/common.h.  There is
-// no separate loop invariant here because a is its own addend, and
-// a = half(a)*half(a) + a is quadratic, so steps cannot be folded together.
+// It used to narrow after every MAC.  That conversion is an uncounted
+// instruction -- it is not in the 4096-op budget -- and sitting in the
+// dependent chain once per counted FMA it issued two instructions per FMA and
+// capped the reading at half the fp32 rate.  An Arc A380 read mp at 2.78
+// TFLOPS against 4.89 for fp32 (57%), where an RTX 5060 sat at 88%.  The old
+// comment here claimed the downcast "does not distort the FMA measurement
+// meaningfully"; on Alchemist it halved it.
 //
-// The MAC is a plain contracted expression rather than fma() for the same
-// reason compute_sp_kernels.cl avoids mad() -- see the comment there.
+// Not to be confused with the even earlier version that carried the fp16
+// value itself through the loop and collapsed at vector widths (0.12x the
+// squaring rate on Intel's CPU runtime from width 4 up).  Nothing in this loop
+// is half; these are fp32 values periodically rounded to fp16 and back.
 //
-// The fp32 accumulator seed carries a get_local_id term.  It is not
-// decoration: without it every operand in this family is uniform across
-// work-items, and a runtime that vectorises across work-items can compute the
-// whole chain once and broadcast it.  Intel's CPU runtime does exactly that.
-// Adding the term dropped the reported figures by 7.96-8.02x at vector widths
-// 2 through 16 -- precisely the AVX2 fp32 lane count -- so every mp number
-// this family produced on such a runtime had been eight times too high.  The
-// corrected figures also finally agree with their surroundings: mp now reads
-// 378 GFLOPS at best against 187 for pure half on the same device, where
-// before it claimed 2077, eleven times the fp16 rate it is built on.
-// Scalar width 1 was only inflated 1.37x, so the broadcast needed the vector
-// types.  Every other backend's mp kernel already seeded from the thread or
-// lane id, which is why this only ever affected OpenCL.
+// Chain shape and why: see the MAD chain block in include/common/common.h.
+//
+// The seed carries a get_local_id term.  It is not decoration: without it
+// every operand in this family is uniform across work-items, and a runtime
+// that vectorises across work-items can compute the whole chain once and
+// broadcast it.  Intel's CPU runtime does exactly that.  Adding the term
+// dropped the reported figures by 7.96-8.02x at vector widths 2 through 16 --
+// precisely the AVX2 fp32 lane count -- so every mp number this family
+// produced on such a runtime had been eight times too high.  Scalar width 1
+// was only inflated 1.37x, so the broadcast needed the vector types.  Every
+// other backend's mp kernel already seeded from the thread or lane id, which
+// is why this only ever affected OpenCL.
 
 \n#if defined(cl_khr_fp16)
 \n  #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 \n  #define HALF_AVAILABLE
 \n#endif
 
+// Plain contracted expression instead of mad() -- see compute_sp_kernels.cl.
+
 \n#undef MAD_4
 \n#undef MAD_16
+\n#undef MAD_128
+\n#undef NARROW
 \n
-\n#define MAD_4(HT, FT, x, a) \
-    a = convert_##FT(x) * convert_##FT(x) + a; x = convert_##HT(a); \
-    a = convert_##FT(x) * convert_##FT(x) + a; x = convert_##HT(a); \
-    a = convert_##FT(x) * convert_##FT(x) + a; x = convert_##HT(a); \
-    a = convert_##FT(x) * convert_##FT(x) + a; x = convert_##HT(a);
-\n#define MAD_16(HT, FT, x, a)  MAD_4(HT,FT,x,a); MAD_4(HT,FT,x,a); MAD_4(HT,FT,x,a); MAD_4(HT,FT,x,a);
+\n#define MAD_4(x, c)     x = (x*x) + c;      x = (x*x) + c;      x = (x*x) + c;      x = (x*x) + c;
+\n#define MAD_16(x, c)    MAD_4(x, c);        MAD_4(x, c);        MAD_4(x, c);        MAD_4(x, c);
+\n#define MAD_128(x, c)   MAD_16(x, c); MAD_16(x, c); MAD_16(x, c); MAD_16(x, c); \
+                          MAD_16(x, c); MAD_16(x, c); MAD_16(x, c); MAD_16(x, c);
+\n#define NARROW(HT, FT, x)  x = convert_##FT(convert_##HT(x));
 \n
 
+\n
 \n#ifdef HALF_AVAILABLE
 \n
 
+
 __kernel void compute_mp_v1(__global float *ptr, float _B)
 {
-    half x = (half)_B;
-    float a = _B + (float)get_local_id(0);
+    float x = (float)((half)_B);
+    float c = (float)((half)((float)get_local_id(0)));
 
-    for(int i=0; i<128; i++)
+    for(int i=0; i<16; i++)
     {
-        MAD_16(half, float, x, a);
+        MAD_128(x, c);
+        NARROW(half, float, x);
     }
 
-    ptr[get_global_id(0)] = a + (float)x;
+    ptr[get_global_id(0)] = x;
 }
 
 __kernel void compute_mp_v2(__global float *ptr, float _B)
 {
-    half2 x = (half2)((half)_B, (half)(_B+1));
-    float2 a = (float2)(_B, _B+1) + (float2)get_local_id(0);
+    float2 x = convert_float2(convert_half2((float2)(_B, _B+1)));
+    float2 c = convert_float2(convert_half2((float2)get_local_id(0)));
 
-    for(int i=0; i<64; i++)
+    for(int i=0; i<8; i++)
     {
-        MAD_16(half2, float2, x, a);
+        MAD_128(x, c);
+        NARROW(half2, float2, x);
     }
 
-    float s = a.S0 + a.S1;
-    ptr[get_global_id(0)] = s + (float)(x.S0);
+    ptr[get_global_id(0)] = x.S0 + x.S1;
 }
 
 __kernel void compute_mp_v4(__global float *ptr, float _B)
 {
-    half4 x = (half4)((half)_B, (half)(_B+1), (half)(_B+2), (half)(_B+3));
-    float4 a = (float4)(_B, _B+1, _B+2, _B+3) + (float4)get_local_id(0);
+    float4 x = convert_float4(convert_half4((float4)(_B, _B+1, _B+2, _B+3)));
+    float4 c = convert_float4(convert_half4((float4)get_local_id(0)));
 
-    for(int i=0; i<32; i++)
+    for(int i=0; i<4; i++)
     {
-        MAD_16(half4, float4, x, a);
+        MAD_128(x, c);
+        NARROW(half4, float4, x);
     }
 
-    float s = a.S0 + a.S1 + a.S2 + a.S3;
-    ptr[get_global_id(0)] = s + (float)(x.S0);
+    ptr[get_global_id(0)] = x.S0 + x.S1 + x.S2 + x.S3;
 }
 
 __kernel void compute_mp_v8(__global float *ptr, float _B)
 {
-    half8 x = (half8)((half)_B, (half)(_B+1), (half)(_B+2), (half)(_B+3),
-                      (half)(_B+4), (half)(_B+5), (half)(_B+6), (half)(_B+7));
-    float8 a = (float8)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7) + (float8)get_local_id(0);
+    float8 x = convert_float8(convert_half8((float8)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7)));
+    float8 c = convert_float8(convert_half8((float8)get_local_id(0)));
 
-    for(int i=0; i<16; i++)
+    for(int i=0; i<2; i++)
     {
-        MAD_16(half8, float8, x, a);
+        MAD_128(x, c);
+        NARROW(half8, float8, x);
     }
 
-    float s = a.S0 + a.S1 + a.S2 + a.S3 + a.S4 + a.S5 + a.S6 + a.S7;
-    ptr[get_global_id(0)] = s + (float)(x.S0);
+    ptr[get_global_id(0)] = x.S0 + x.S1 + x.S2 + x.S3 + x.S4 + x.S5 + x.S6 + x.S7;
 }
 
 __kernel void compute_mp_v16(__global float *ptr, float _B)
 {
-    half16 x = (half16)((half)_B,     (half)(_B+1),  (half)(_B+2),  (half)(_B+3),
-                        (half)(_B+4), (half)(_B+5),  (half)(_B+6),  (half)(_B+7),
-                        (half)(_B+8), (half)(_B+9),  (half)(_B+10), (half)(_B+11),
-                        (half)(_B+12),(half)(_B+13), (half)(_B+14), (half)(_B+15));
-    float16 a = (float16)(_B,    _B+1,  _B+2,  _B+3,  _B+4,  _B+5,  _B+6,  _B+7,
-                          _B+8,  _B+9,  _B+10, _B+11, _B+12, _B+13, _B+14, _B+15)
-                + (float16)get_local_id(0);
+    float16 x = convert_float16(convert_half16((float16)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7, _B+8, _B+9, _B+10, _B+11, _B+12, _B+13, _B+14, _B+15)));
+    float16 c = convert_float16(convert_half16((float16)get_local_id(0)));
 
-    for(int i=0; i<8; i++)
+    for(int i=0; i<1; i++)
     {
-        MAD_16(half16, float16, x, a);
+        MAD_128(x, c);
+        NARROW(half16, float16, x);
     }
 
-    float8 t = a.lo + a.hi;
-    float4 t2 = t.lo + t.hi;
-    float2 t3 = t2.lo + t2.hi;
-    ptr[get_global_id(0)] = t3.S0 + t3.S1 + (float)(x.S0);
+    ptr[get_global_id(0)] = x.S0 + x.S1 + x.S2 + x.S3 + x.S4 + x.S5 + x.S6 + x.S7 + x.S8 + x.S9 + x.SA + x.SB + x.SC + x.SD + x.SE + x.SF;
 }
 
 // ---- affine-chain variants (generated; see mad_chain.cl) ----
-//
-// The invariant multiplier m is seeded from _B rather than get_local_id.  A
-// varying half operand cost 8x on Intel's CPU runtime from vector width 4 up
-// (0.12x the squaring rate); with m uniform the alt matches or beats the
-// squaring chain at every width.  The fp32 accumulator seed carries the
-// per-work-item variation instead, matching the squaring kernels above.
 
 __kernel void compute_mp_alt_v1(__global float *ptr, float _B)
 {
-    MP4_DECL(half, float, (half)((half)(_B + 0.5f)), (half)_B, _B + (float)get_local_id(0))
+    AF4_DECL(float, (float)((half)_B), (float)((half)((float)get_local_id(0))))
 
-    for (int i = 0; i < 128; i++)
+    for (int i = 0; i < 16; i++)
     {
-        MP4_16(half, float)
+        MP4_128
+        MP4_NARROW(half, float)
     }
 
-    float r = MP4_RES(float);
+    float r = AF4_RES;
     ptr[get_global_id(0)] = r;
 }
 
 __kernel void compute_mp_alt_v2(__global float *ptr, float _B)
 {
-    MP2_DECL(half2, float2, (half2)((half)(_B + 0.5f)), (half2)((half)_B, (half)(_B+1)), (float2)(_B, _B+1) + (float2)get_local_id(0))
+    AF2_DECL(float2, convert_float2(convert_half2((float2)(_B, _B+1))), convert_float2(convert_half2((float2)get_local_id(0))))
 
-    for (int i = 0; i < 64; i++)
+    for (int i = 0; i < 8; i++)
     {
-        MP2_16(half2, float2)
+        MP2_128
+        MP2_NARROW(half2, float2)
     }
 
-    float2 r = MP2_RES(float2);
+    float2 r = AF2_RES;
     ptr[get_global_id(0)] = r.S0 + r.S1;
 }
 
 __kernel void compute_mp_alt_v4(__global float *ptr, float _B)
 {
-    MP1_DECL(half4, float4, (half4)((half)(_B + 0.5f)), (half4)((half)_B, (half)(_B+1), (half)(_B+2), (half)(_B+3)), (float4)(_B, _B+1, _B+2, _B+3) + (float4)get_local_id(0))
+    AF1_DECL(float4, convert_float4(convert_half4((float4)(_B, _B+1, _B+2, _B+3))), convert_float4(convert_half4((float4)get_local_id(0))))
 
-    for (int i = 0; i < 32; i++)
+    for (int i = 0; i < 4; i++)
     {
-        MP1_16(half4, float4)
+        MP1_128
+        MP1_NARROW(half4, float4)
     }
 
-    float4 r = MP1_RES(float4);
+    float4 r = AF1_RES;
     ptr[get_global_id(0)] = r.S0 + r.S1 + r.S2 + r.S3;
 }
 
 __kernel void compute_mp_alt_v8(__global float *ptr, float _B)
 {
-    MP1_DECL(half8, float8, (half8)((half)(_B + 0.5f)), (half8)((half)_B, (half)(_B+1), (half)(_B+2), (half)(_B+3), (half)(_B+4), (half)(_B+5), (half)(_B+6), (half)(_B+7)), (float8)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7) + (float8)get_local_id(0))
+    AF1_DECL(float8, convert_float8(convert_half8((float8)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7))), convert_float8(convert_half8((float8)get_local_id(0))))
 
-    for (int i = 0; i < 16; i++)
+    for (int i = 0; i < 2; i++)
     {
-        MP1_16(half8, float8)
+        MP1_128
+        MP1_NARROW(half8, float8)
     }
 
-    float8 r = MP1_RES(float8);
+    float8 r = AF1_RES;
     ptr[get_global_id(0)] = r.S0 + r.S1 + r.S2 + r.S3 + r.S4 + r.S5 + r.S6 + r.S7;
 }
 
 __kernel void compute_mp_alt_v16(__global float *ptr, float _B)
 {
-    MP1_DECL(half16, float16, (half16)((half)(_B + 0.5f)), (half16)((half)_B, (half)(_B+1), (half)(_B+2), (half)(_B+3), (half)(_B+4), (half)(_B+5), (half)(_B+6), (half)(_B+7), (half)(_B+8), (half)(_B+9), (half)(_B+10), (half)(_B+11), (half)(_B+12), (half)(_B+13), (half)(_B+14), (half)(_B+15)), (float16)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7, _B+8, _B+9, _B+10, _B+11, _B+12, _B+13, _B+14, _B+15) + (float16)get_local_id(0))
+    AF1_DECL(float16, convert_float16(convert_half16((float16)(_B, _B+1, _B+2, _B+3, _B+4, _B+5, _B+6, _B+7, _B+8, _B+9, _B+10, _B+11, _B+12, _B+13, _B+14, _B+15))), convert_float16(convert_half16((float16)get_local_id(0))))
 
-    for (int i = 0; i < 8; i++)
+    for (int i = 0; i < 1; i++)
     {
-        MP1_16(half16, float16)
+        MP1_128
+        MP1_NARROW(half16, float16)
     }
 
-    float16 r = MP1_RES(float16);
-    float8 t = r.lo + r.hi;
-    float4 t2 = t.lo + t.hi;
-    float2 t3 = t2.lo + t2.hi;
-    ptr[get_global_id(0)] = t3.S0 + t3.S1;
+    float16 r = AF1_RES;
+    ptr[get_global_id(0)] = r.S0 + r.S1 + r.S2 + r.S3 + r.S4 + r.S5 + r.S6 + r.S7 + r.S8 + r.S9 + r.SA + r.SB + r.SC + r.SD + r.SE + r.SF;
 }
 
 \n#endif      // HALF_AVAILABLE

--- a/src/opencl/kernels/mad_chain.cl
+++ b/src/opencl/kernels/mad_chain.cl
@@ -49,17 +49,30 @@ MSTRINGIFY(
 // M24_* is the same rotating shape as RT*, spelled with mad24 for the 24-bit
 // fast-integer family.
 //
-// MP* is the mixed-precision family's second shape, and it is deliberately a
-// one-token edit of the squaring kernel rather than a rewrite:
+// MP* is the mixed-precision family's second shape.  It is now just AF* over
+// an fp32 accumulator with a narrowing round-trip every 128 chain
+// instructions (MP*_128 + MP*_NARROW), which is the shape the CUDA, ROCm,
+// Metal, Vulkan and oneAPI mp kernels all use.
 //
-//   squaring   a = wide(x) * wide(x) + a;  x = narrow(a);   sources {x, x, a}
-//   MP*        a = wide(m) * wide(x) + a;  x = narrow(a);   sources {m, x, a}
+// It used to narrow once per MAC, inside the chain:
 //
-// The fp32 accumulator stays loop-carried and the narrowing stays where it
-// was, so the only difference is the duplicated multiplicand.  An earlier
-// version carried the fp16 value through the loop instead and collapsed at
-// vector widths -- 0.12x the squaring rate on Intel's CPU runtime from width
-// 4 up.  The narrowing blocks any fold outright, affine form or not.
+//   old   a = wide(m) * wide(x) + a;  x = narrow(a);   every step
+//
+// which put an uncounted conversion in the dependent chain for every counted
+// FMA -- two instructions issued per FMA, so at best half the fp32 rate.  An
+// Arc A380 read 2.78 TFLOPS against 4.89 for fp32.  Note this is not a return
+// to the version that carried the fp16 value through the loop and collapsed
+// at vector widths (0.12x the squaring rate on Intel's CPU runtime from width
+// 4 up): there are no half operands inside the loop at all now, only fp32
+// values that are periodically rounded to fp16 and back.
+//
+// Because nothing in the loop is half any more, the old requirement that the
+// invariant multiplier stay uniform across work-items is gone -- a is an fp32
+// value and is seeded from the lane id, as the oneAPI mp alt kernel does.  The
+// per-work-item variation the family needs (see compute_mp_kernels.cl) comes
+// from it either way.  Folding is held off by the same thing that holds it off
+// for AF*: the fold needs FP reassociation, which nothing in the toolchain set
+// does by default, with MAX_ALT_CHAIN_RATIO as the backstop.
 //
 // runComputeTest also refuses an alt reading more than MAX_ALT_CHAIN_RATIO
 // times the squaring one, as a backstop against a fold nobody predicted.
@@ -105,12 +118,13 @@ MSTRINGIFY(
 \n#undef RT2_G
 \n#undef RT2_16
 \n#undef RT2_RES
-\n#undef MP4_DECL
-\n#undef MP4_16
-\n#undef MP2_DECL
-\n#undef MP2_16
-\n#undef MP1_DECL
-\n#undef MP1_16
+\n#undef MP_NARROW
+\n#undef MP4_128
+\n#undef MP4_NARROW
+\n#undef MP2_128
+\n#undef MP2_NARROW
+\n#undef MP1_128
+\n#undef MP1_NARROW
 \n#undef M24_4_DECL
 \n#undef M24_4_16
 \n#undef M24_2_DECL
@@ -144,22 +158,28 @@ MSTRINGIFY(
 \n#define RT2_16                 RT2_G RT2_G RT2_G RT2_G RT2_G RT2_G RT2_G RT2_G
 \n#define RT2_RES                (x0 + x1)
 \n
-\n#define MP_STEP(HT, FT, x, a, m)  a = convert_##FT(m) * convert_##FT(x) + a; x = convert_##HT(a);
+\n// Mixed-precision (mp) chains.  The accumulator is FT throughout and the
+\n// narrow round-trip happens once per MP*_128 round, not once per MAC: the
+\n// conversion is an uncounted instruction sitting in the dependent chain, so
+\n// at one per MAC it issued two instructions per counted FMA and halved the
+\n// reading.  An Arc A380 read mp at 2.78 TFLOPS against 4.89 for fp32 (57%)
+\n// before this; the other five backends had always amortised it.  Matches the
+\n// depth compute_bf16_v*.comp and the oneAPI bf16 kernel already used.
+\n//
+\n// These reuse the AF* float chains -- there are no half operands left inside
+\n// the loop, so the "keep the multiplier uniform" rule the old MP_STEP form
+\n// needed no longer applies; a is a float and may vary per work-item, exactly
+\n// as the oneAPI mp alt kernel seeds it.
+\n#define MP_NARROW(HT, FT, x)   x = convert_##FT(convert_##HT(x));
 \n
-\n#define MP4_DECL(HT, FT, mseed, xseed, aseed) HT m = (mseed); HT x0 = (xseed); HT x1 = (xseed) + (HT)(CH_STRIDE); HT x2 = (xseed) + (HT)(2*CH_STRIDE); HT x3 = (xseed) + (HT)(3*CH_STRIDE); FT a0 = (aseed); FT a1 = (aseed) + (FT)(CH_STRIDE); FT a2 = (aseed) + (FT)(2*CH_STRIDE); FT a3 = (aseed) + (FT)(3*CH_STRIDE);
-\n#define MP4_G(HT, FT)          MP_STEP(HT,FT,x0,a0,m) MP_STEP(HT,FT,x1,a1,m) MP_STEP(HT,FT,x2,a2,m) MP_STEP(HT,FT,x3,a3,m)
-\n#define MP4_16(HT, FT)         MP4_G(HT,FT) MP4_G(HT,FT) MP4_G(HT,FT) MP4_G(HT,FT)
-\n#define MP4_RES(FT)            (((a0 + a1) + (a2 + a3)) + convert_##FT(x0))
+\n#define MP4_128                AF4_16 AF4_16 AF4_16 AF4_16 AF4_16 AF4_16 AF4_16 AF4_16
+\n#define MP4_NARROW(HT, FT)     MP_NARROW(HT,FT,x0) MP_NARROW(HT,FT,x1) MP_NARROW(HT,FT,x2) MP_NARROW(HT,FT,x3)
 \n
-\n#define MP2_DECL(HT, FT, mseed, xseed, aseed) HT m = (mseed); HT x0 = (xseed); HT x1 = (xseed) + (HT)(CH_STRIDE); FT a0 = (aseed); FT a1 = (aseed) + (FT)(CH_STRIDE);
-\n#define MP2_G(HT, FT)          MP_STEP(HT,FT,x0,a0,m) MP_STEP(HT,FT,x1,a1,m)
-\n#define MP2_16(HT, FT)         MP2_G(HT,FT) MP2_G(HT,FT) MP2_G(HT,FT) MP2_G(HT,FT) MP2_G(HT,FT) MP2_G(HT,FT) MP2_G(HT,FT) MP2_G(HT,FT)
-\n#define MP2_RES(FT)            ((a0 + a1) + convert_##FT(x0))
+\n#define MP2_128                AF2_16 AF2_16 AF2_16 AF2_16 AF2_16 AF2_16 AF2_16 AF2_16
+\n#define MP2_NARROW(HT, FT)     MP_NARROW(HT,FT,x0) MP_NARROW(HT,FT,x1)
 \n
-\n#define MP1_DECL(HT, FT, mseed, xseed, aseed) HT m = (mseed); HT x0 = (xseed); FT a0 = (aseed);
-\n#define MP1_G(HT, FT)          MP_STEP(HT,FT,x0,a0,m)
-\n#define MP1_16(HT, FT)         MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT) MP1_G(HT,FT)
-\n#define MP1_RES(FT)            (a0 + convert_##FT(x0))
+\n#define MP1_128                AF1_16 AF1_16 AF1_16 AF1_16 AF1_16 AF1_16 AF1_16 AF1_16
+\n#define MP1_NARROW(HT, FT)     MP_NARROW(HT,FT,x0)
 \n
 \n#define M24_MAD(d, m1, m2, ad)  d = mad24(m1, m2, ad);
 \n

--- a/src/rocm/rocm_kernels/compute_mp.hip
+++ b/src/rocm/rocm_kernels/compute_mp.hip
@@ -7,6 +7,8 @@
 
 #define MAD_4(x, c)  x = fmaf(x, x, c); x = fmaf(x, x, c); x = fmaf(x, x, c); x = fmaf(x, x, c);
 #define MAD_16(x, c) MAD_4(x, c) MAD_4(x, c) MAD_4(x, c) MAD_4(x, c)
+#define MAD_128(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) \
+                      MAD_16(x, c) MAD_16(x, c) MAD_16(x, c) MAD_16(x, c)
 
 extern "C" __global__ void compute_mp(float *out, float A)
 {
@@ -14,9 +16,9 @@ extern "C" __global__ void compute_mp(float *out, float A)
     float c = __half2float(__float2half((float)threadIdx.x));
 
     #pragma unroll 1
-    for (int i = 0; i < 128; i++)
+    for (int i = 0; i < 16; i++)
     {
-        MAD_16(x, c)
+        MAD_128(x, c)
         x = __half2float(__float2half(x));
     }
 

--- a/src/vulkan/shaders/compute_hp_v1.comp
+++ b/src/vulkan/shaders/compute_hp_v1.comp
@@ -20,7 +20,10 @@ layout(push_constant) uniform PushConstants {
 // Compiled twice -- squaring chain and affine chain -- and raced against
 // each other at run time.  See mad_chain.glsl, and the MAD chain block in
 // include/common/common.h for the rules both shapes obey.
-#define MAD_CHAINS 4
+// fp16 accumulators pack two per 32-bit register, so these carry 8 values --
+// twice the fp32 shaders' value count, the same register footprint.  See the
+// MAD_CHAINS block in mad_chain.glsl for why the budget is registers.
+#define MAD_CHAINS 8
 #include "mad_chain.glsl"
 
 void main()

--- a/src/vulkan/shaders/compute_hp_v2.comp
+++ b/src/vulkan/shaders/compute_hp_v2.comp
@@ -20,7 +20,10 @@ layout(push_constant) uniform PushConstants {
 // Compiled twice -- squaring chain and affine chain -- and raced against
 // each other at run time.  See mad_chain.glsl, and the MAD chain block in
 // include/common/common.h for the rules both shapes obey.
-#define MAD_CHAINS 2
+// fp16 accumulators pack two per 32-bit register, so these carry 8 values --
+// twice the fp32 shaders' value count, the same register footprint.  See the
+// MAD_CHAINS block in mad_chain.glsl for why the budget is registers.
+#define MAD_CHAINS 4
 #include "mad_chain.glsl"
 
 void main()

--- a/src/vulkan/shaders/compute_hp_v4.comp
+++ b/src/vulkan/shaders/compute_hp_v4.comp
@@ -20,7 +20,10 @@ layout(push_constant) uniform PushConstants {
 // Compiled twice -- squaring chain and affine chain -- and raced against
 // each other at run time.  See mad_chain.glsl, and the MAD chain block in
 // include/common/common.h for the rules both shapes obey.
-#define MAD_CHAINS 1
+// fp16 accumulators pack two per 32-bit register, so these carry 8 values --
+// twice the fp32 shaders' value count, the same register footprint.  See the
+// MAD_CHAINS block in mad_chain.glsl for why the budget is registers.
+#define MAD_CHAINS 2
 #include "mad_chain.glsl"
 
 void main()

--- a/src/vulkan/shaders/compute_mp_v1.comp
+++ b/src/vulkan/shaders/compute_mp_v1.comp
@@ -26,14 +26,20 @@ layout(push_constant) uniform PushConstants {
 // Compiled twice -- squaring chain and affine chain -- and raced against
 // each other at run time.  See mad_chain.glsl, and the MAD chain block in
 // include/common/common.h for the rules both shapes obey.
-// Standard per-width chain counts, despite the fp16 round-trip below
-// running once per accumulator: N chains cost N conversions per 16 chain
-// instructions against the squaring build's one, but both builds report the
-// same op budget, so the extra conversions can only understate the affine
-// reading -- never inflate it -- and runComputeKernel takes the maximum.
-// Forcing one chain to even up the conversion count cost an RTX 5060 10.6%
-// on mp2 (15726 -> 14061 GFLOPS), because NVIDIA's three-register mad needs
-// the independent chains.
+// Standard per-width chain counts, despite the fp16 round-trip below running
+// once per accumulator.  Forcing one chain to even up the conversion count
+// cost an RTX 5060 10.6% on mp2 (15726 -> 14061 GFLOPS), because NVIDIA's
+// three-register mad needs the independent chains.
+//
+// The N conversions those chains cost are why the inner loop is MAD_128 and
+// not MAD_16, matching compute_bf16_v*.  At MAD_16 the affine build paid N
+// conversions per 16 chain instructions -- 25% uncounted instruction overhead
+// at 4 chains -- and on Alchemist that is not a shape you can decline: the
+// squaring build, which needs only one conversion per round, is the one the
+// three-distinct-source rule halves there.  Cheap conversions or a full-rate
+// mad, never both, so an Arc A380 read mp at 2.78 TFLOPS against 4.89 for
+// fp32 (57%) where an RTX 5060, free to take the squaring build, sat at 88%.
+// Over 128 the same N conversions cost ~3%, so both shapes stay usable.
 #define MAD_CHAINS 4
 #include "mad_chain.glsl"
 
@@ -43,10 +49,10 @@ void main()
 {
     CHAIN_DECL(float, float(float16_t(pc.A)), float(float16_t(gl_LocalInvocationID.x)))
 
-    // 128 iters * 16 FMAs * 2 ops = 4096 per WI (COMPUTE_FP_WORK_PER_WI).
-    for (int i = 0; i < 128; i++)
+    // 16 iters * 128 FMAs * 2 ops = 4096 per WI (COMPUTE_FP_WORK_PER_WI).
+    for (int i = 0; i < 16; i++)
     {
-        MAD_16
+        MAD_128
         CHAIN_MAP(NARROW)
     }
 

--- a/src/vulkan/shaders/compute_mp_v2.comp
+++ b/src/vulkan/shaders/compute_mp_v2.comp
@@ -26,14 +26,20 @@ layout(push_constant) uniform PushConstants {
 // Compiled twice -- squaring chain and affine chain -- and raced against
 // each other at run time.  See mad_chain.glsl, and the MAD chain block in
 // include/common/common.h for the rules both shapes obey.
-// Standard per-width chain counts, despite the fp16 round-trip below
-// running once per accumulator: N chains cost N conversions per 16 chain
-// instructions against the squaring build's one, but both builds report the
-// same op budget, so the extra conversions can only understate the affine
-// reading -- never inflate it -- and runComputeKernel takes the maximum.
-// Forcing one chain to even up the conversion count cost an RTX 5060 10.6%
-// on mp2 (15726 -> 14061 GFLOPS), because NVIDIA's three-register mad needs
-// the independent chains.
+// Standard per-width chain counts, despite the fp16 round-trip below running
+// once per accumulator.  Forcing one chain to even up the conversion count
+// cost an RTX 5060 10.6% on mp2 (15726 -> 14061 GFLOPS), because NVIDIA's
+// three-register mad needs the independent chains.
+//
+// The N conversions those chains cost are why the inner loop is MAD_128 and
+// not MAD_16, matching compute_bf16_v*.  At MAD_16 the affine build paid N
+// conversions per 16 chain instructions -- 25% uncounted instruction overhead
+// at 4 chains -- and on Alchemist that is not a shape you can decline: the
+// squaring build, which needs only one conversion per round, is the one the
+// three-distinct-source rule halves there.  Cheap conversions or a full-rate
+// mad, never both, so an Arc A380 read mp at 2.78 TFLOPS against 4.89 for
+// fp32 (57%) where an RTX 5060, free to take the squaring build, sat at 88%.
+// Over 128 the same N conversions cost ~3%, so both shapes stay usable.
 #define MAD_CHAINS 2
 #include "mad_chain.glsl"
 
@@ -43,10 +49,10 @@ void main()
 {
     CHAIN_DECL(vec2, vec2(f16vec2(pc.A, pc.A + 1.0)), vec2(f16vec2(gl_LocalInvocationID.x)))
 
-    // 128 iters * 16 FMAs * 2 ops = 4096 per WI (COMPUTE_FP_WORK_PER_WI).
-    for (int i = 0; i < 64; i++)
+    // 16 iters * 128 FMAs * 2 ops = 4096 per WI (COMPUTE_FP_WORK_PER_WI).
+    for (int i = 0; i < 8; i++)
     {
-        MAD_16
+        MAD_128
         CHAIN_MAP(NARROW)
     }
 

--- a/src/vulkan/shaders/compute_mp_v4.comp
+++ b/src/vulkan/shaders/compute_mp_v4.comp
@@ -26,6 +26,11 @@ layout(push_constant) uniform PushConstants {
 // Compiled twice -- squaring chain and affine chain -- and raced against
 // each other at run time.  See mad_chain.glsl, and the MAD chain block in
 // include/common/common.h for the rules both shapes obey.
+//
+// The inner loop is MAD_128, not MAD_16, matching compute_bf16_v*: the fp16
+// round-trip below runs once per accumulator per round, and at MAD_16 that
+// was up to 25% uncounted instruction overhead across the width sweep.  See
+// compute_mp_v1.comp for the Alchemist measurement that forced it.
 #define MAD_CHAINS 1
 #include "mad_chain.glsl"
 
@@ -35,10 +40,10 @@ void main()
 {
     CHAIN_DECL(vec4, vec4(f16vec4(pc.A, pc.A + 1.0, pc.A + 2.0, pc.A + 3.0)), vec4(f16vec4(gl_LocalInvocationID.x)))
 
-    // 128 iters * 16 FMAs * 2 ops = 4096 per WI (COMPUTE_FP_WORK_PER_WI).
-    for (int i = 0; i < 32; i++)
+    // 16 iters * 128 FMAs * 2 ops = 4096 per WI (COMPUTE_FP_WORK_PER_WI).
+    for (int i = 0; i < 4; i++)
     {
-        MAD_16
+        MAD_128
         CHAIN_MAP(NARROW)
     }
 

--- a/src/vulkan/shaders/mad_chain.glsl
+++ b/src/vulkan/shaders/mad_chain.glsl
@@ -33,9 +33,23 @@
 // tested (Arc A380, RTX 5060, RTX 4060, Arc UHD 630, Adreno X1-45, M1 Pro via
 // MoltenVK) where the squaring form alone reports half rate on Alchemist.
 //
-// MAD_CHAINS is set by the includer: 4 at vector width 1, 2 at width 2, 1 at
-// width 4, keeping live values per lane at ~5 whatever the width -- the
-// register-pressure rule in include/common/common.h still applies.
+// MAD_CHAINS is set by the includer to hold the chain state at ~4 32-bit
+// registers per lane whatever the vector width -- the register-pressure rule
+// in include/common/common.h still applies.  For 32-bit accumulators that is
+// 4 values: 4 chains at width 1, 2 at width 2, 1 at width 4.
+//
+// Note that the budget is registers, not values.  Two fp16 accumulators share
+// one 32-bit register, so a 16-bit-accumulator shader has to carry 8 values to
+// reach the same footprint -- 8 chains at width 1, 4 at width 2, 2 at width 4.
+// Normalising on values instead halves the independent-FMA count on hardware
+// that issues fp16 two per lane, which is the wrong direction: such hardware
+// also retires fp16 twice as fast, so it needs more chains in flight, not
+// fewer.  An Arc A380 (fp16 peak 10.04 TFLOPS) read 4.94 TFLOPS on all three
+// hp widths at 4 values -- flat across the sweep, because cutting MAD_CHAINS
+// in lockstep with the width meant the sweep never varied the ILP at all --
+// against 9.84 from oneAPI and 9.56 from OpenCL, whose sweeps reach half8/
+// half16 and so clear the bar.  Only compute_hp_v* is affected: mp and bf16
+// carry their chains in vec2/vec4 and are already at 4 registers.
 //
 // MAD_CHAIN_INTEGER selects a rotating second shape instead of the affine one;
 // integer shaders must set it, because an integer affine recurrence folds
@@ -100,7 +114,22 @@
 
 #elif defined(MAD_CHAIN_AFFINE)
 
-  #if MAD_CHAINS == 4
+  #if MAD_CHAINS == 8
+    #define CHAIN_DECL(T, seed, inv)                                          \
+        T a = (inv);  T b = a + T(2);                                         \
+        T x0 = (seed);                         T x1 = (seed) + T(MAD_CHAIN_STRIDE); \
+        T x2 = (seed) + T(2*MAD_CHAIN_STRIDE); T x3 = (seed) + T(3*MAD_CHAIN_STRIDE); \
+        T x4 = (seed) + T(4*MAD_CHAIN_STRIDE); T x5 = (seed) + T(5*MAD_CHAIN_STRIDE); \
+        T x6 = (seed) + T(6*MAD_CHAIN_STRIDE); T x7 = (seed) + T(7*MAD_CHAIN_STRIDE);
+    #define MAD_GROUP    MAD_OP(x0, a, x0, b) MAD_OP(x1, a, x1, b) \
+                         MAD_OP(x2, a, x2, b) MAD_OP(x3, a, x3, b) \
+                         MAD_OP(x4, a, x4, b) MAD_OP(x5, a, x5, b) \
+                         MAD_OP(x6, a, x6, b) MAD_OP(x7, a, x7, b)
+    #define MAD_16       MAD_GROUP MAD_GROUP
+    #define CHAIN_MAP(f) x0 = f(x0); x1 = f(x1); x2 = f(x2); x3 = f(x3); \
+                         x4 = f(x4); x5 = f(x5); x6 = f(x6); x7 = f(x7);
+    #define CHAIN_RESULT (((x0 + x1) + (x2 + x3)) + ((x4 + x5) + (x6 + x7)))
+  #elif MAD_CHAINS == 4
     #define CHAIN_DECL(T, seed, inv)                                          \
         T a = (inv);  T b = a + T(2);                                         \
         T x0 = (seed);                         T x1 = (seed) + T(MAD_CHAIN_STRIDE); \


### PR DESCRIPTION
Two fixes to the fp16 compute kernels, plus a results refresh.

### 1. `370f1b2` — fix(vulkan): give the fp16 shaders the same register budget as fp32

`MAD_CHAINS` was being set to hold **4 values** in flight at every vector width, but the
constraint it exists to respect is **register pressure**, and two fp16 accumulators pack into one
32-bit register. So every `compute_hp_v*` shader ran at half the register footprint — and half
the independent-FMA count — of the `compute_sp_v*` shader its reading is compared against. That
is backwards on hardware that issues fp16 two-per-lane: such hardware also *retires* fp16 twice
as fast, so it needs more chains in flight, not fewer.

Chain counts doubled for the three hp shaders, plus the 8-chain affine arm they now need:

| shader | width | before | after |
|---|---|---|---|
| `compute_hp_v1.comp` | 1 | 4 | **8** |
| `compute_hp_v2.comp` | 2 | 2 | **4** |
| `compute_hp_v4.comp` | 4 | 1 | **2** |

`MAD_16` still spells exactly 16 chain instructions in every arm, so the 4096 ops/work-item
budget and the comparability of the two raced shapes are unchanged. Only `compute_hp_v*` is
affected — mp and bf16 carry their chains in `vec2`/`vec4` and were already at 4 registers.

*Files:* `compute_hp_v{1,2,4}.comp`, `mad_chain.glsl`

### 2. `940fa86` — fix(mp): amortise the fp16 round-trip across all six backends

The mixed-precision family never got the loop deepening bf16 got in `f6ea4c4`. Every mp kernel
still narrowed its accumulator back through fp16 **once per 16 chain instructions**, and
OpenCL's narrowed **once per MAC**. That conversion is an uncounted instruction — not in the
4096-op budget — and it sits in the dependent chain, so it comes straight off the reading.

It stayed invisible on NVIDIA because the squaring build needs only one conversion per round and
NVIDIA is free to take it. Alchemist has no such option: there the squaring build is the one the
three-distinct-source rule halves, forcing the race onto the affine build — precisely the build
carrying N conversions per round, one per chain. Cheap conversions or a full-rate mad, never both.

Fix: **128 chain instructions per narrowing round** in every backend (matching
`compute_bf16_v*` and the oneAPI bf16 kernel). N conversions per 128 costs ~3% instead of ~25%,
so both shapes stay usable and the shape race becomes a real choice again.

OpenCL needed more than a depth change — its `MP_STEP` form narrowed *inside* the chain on every
MAC, two instructions issued per counted FMA, capping it at half the fp32 rate before any of the
above. Rebuilt on the existing `AF*` float chains with `MP*_128` + `MP*_NARROW`. Nothing in the
loop is `half` any more: these are fp32 values periodically rounded to fp16 and back, the same
structure the other five backends already had. (Not the earlier version that carried fp16
*through* the loop and collapsed at vector widths.) With no half operands left, the
"keep the invariant multiplier uniform" rule no longer applies, so it is seeded from the lane id
as oneAPI's alt kernel does; the per-work-item variation that stops a CPU runtime broadcasting
the whole chain is preserved.