### PR TITLE
fix(cpu, onnx): emulation-aware div/sqrt rows, paired gemm fold suppression

### DIFF
--- a/include/cpu/cpu_peak.h
+++ b/include/cpu/cpu_peak.h
@@ -61,6 +61,10 @@ struct cpu_device_info_t {
   bool hasSME    = false;           // ARM SME (streaming matrix engine; Apple M4+, Oryon Gen 3)
   bool hasSME2   = false;           // ARM SME2
   int  smeSVLBytes = 0;             // active SME streaming vector length in bytes (0 if no SME)
+  bool emulatedX86OnArm = false;    // x86 binary translated on ARM64 (Prism/Rosetta/qemu-user):
+                                    // guest CPUID claims AVX2/AVX-512, but ops/lane scaling does
+                                    // not match the emulated execution width, so wider div/sqrt
+                                    // rows are suppressed.
 };
 
 // Populate `info` from the host (cpu_device.cpp).

--- a/src/cpu/AGENTS.md
+++ b/src/cpu/AGENTS.md
@@ -228,6 +228,14 @@ changing a kernel.
   target features, so it must enter intrinsic branches via the GNU macros only.
 - **The NEON kernels are AArch64-only** (fused FMA, horizontal reduce and fp16
   store have no ARMv7 equivalent), so armeabi-v7a uses the scalar `generic` TU.
+- **Wider-than-128b divide/sqrt rows are suppressed for x86 binaries translated
+  on ARM64** (Windows Prism, Apple Rosetta 2, Linux qemu-user).  Guest CPUID
+  still advertises AVX2/AVX-512, but the host only executes 128-bit NEON, so
+  counting 256-bit guest lanes inflates the result (Snapdragon X: AVX2 fdiv
+  read 1.4-1.6x above native NEON).  `kernelMenu()` skips `addDivSqrt()` for
+  the AVX2/AVX-512 TUs when `CpuFeatures::emulatedX86OnArm` is true; other
+  compute families are left untouched.  System-VM emulation (qemu-system-x86_64
+  on ARM) is not detected because the guest kernel reports x86_64 in `uname`.
 
 ## Reference points
 

--- a/src/cpu/compute_float.cpp
+++ b/src/cpu/compute_float.cpp
@@ -76,13 +76,21 @@ int CpuPeak::runComputeDivSqrt(benchmark_config_t &cfg)
   // One test, four readings: divide and square root run on the same narrow
   // unit, and its profile across the two operations and both precisions is
   // one fact about the CPU, not four.
+  std::string divDesc =
+      "How many divisions and square roots per second the CPU sustains. "
+      "Both run on their own narrow unit rather than the wide "
+      "multiply-add pipeline, so these land far below the compute rows "
+      "-- and the gap between CPU generations here is much larger.";
+  // Under x64-on-ARM64 translation only the 128-bit row is shown: a 256-bit
+  // guest divide is cracked to 2x128-bit host ops, so counting guest lanes
+  // would report emulation overhead as silicon peak (Snapdragon X read AVX2
+  // fdiv 1.4-1.6x above NEON for the same divider).
+  if (info.emulatedX86OnArm)
+    divDesc += "  This x64 binary is translated on an ARM64 host, so only "
+               "the 128-bit row is reported.";
   emitFamily(*this,
              {"divide_sqrt", "Divide and square-root throughput", "flops",
-              Category::Unknown,
-              "How many divisions and square roots per second the CPU sustains. "
-              "Both run on their own narrow unit rather than the wide "
-              "multiply-add pipeline, so these land far below the compute rows "
-              "-- and the gap between CPU generations here is much larger.",
+              Category::Unknown, divDesc,
               TestShape::Heterogeneous, "operation"},
              {{ "fdiv fp32", "Division on 32-bit floats.",
                 "no SIMD fp32 divide path for this CPU", &kernelMenu().div32 },

--- a/src/cpu/cpu_device.cpp
+++ b/src/cpu/cpu_device.cpp
@@ -395,6 +395,7 @@ static void detectIsa(cpu_device_info_t &info)
   info.hasSME     = f.sme;
   info.hasSME2    = f.sme2;
   info.smeSVLBytes = clpeak_cpu::smeSVLBytes();
+  info.emulatedX86OnArm = f.emulatedX86OnArm;
   info.isaName    = clpeak_cpu::isaName();
   // Report the active SVE vector length alongside the ISA name, e.g.
   // "SVE2 (VL=256b)" -- it's the defining knob for SVE peak throughput.

--- a/src/cpu/cpu_dispatch.cpp
+++ b/src/cpu/cpu_dispatch.cpp
@@ -4,6 +4,7 @@
 #include "cpu_tu_registry.h"
 
 #include <cstdint>
+#include <cstring>
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #define CLPEAK_X86 1
@@ -27,6 +28,7 @@
 #if defined(__linux__) && defined(CLPEAK_X86)
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <sys/utsname.h>
 #elif defined(_WIN32) && defined(CLPEAK_X86)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -54,6 +56,50 @@ static inline uint64_t xgetbv0()
   uint32_t a, d;
   __asm__ volatile("xgetbv" : "=a"(a), "=d"(d) : "c"(0));
   return ((uint64_t)d << 32) | a;
+#endif
+}
+
+// x86 binary translated on an ARM64 host (Windows Prism, Apple Rosetta 2,
+// Linux qemu-user/binfmt).  Guest CPUID still advertises AVX2/AVX-512, but the
+// host executes 128-bit NEON: counting guest lanes inflates wider divider
+// rows (AVX2 cracked to 2x128b takes ~2x time for 2x ops, and Prism's div
+// cracking is uneven enough to read above native).  kernelMenu() uses this to
+// suppress wider-than-128b div/sqrt rows.
+//
+// Detection coverage:
+//   - Windows Prism: IsWow64Process2 returns procMachine=x64, nativeMachine=ARM64.
+//   - Apple Rosetta 2: sysctl.proc_translated is set.
+//   - Linux qemu-user/binfmt: uname().machine reports the host arch (aarch64*).
+// Does NOT catch system-VM emulation (qemu-system-x86_64 on ARM host) because
+// the guest kernel reports x86_64 in uname; those runs still show inflated
+// AVX2/AVX-512 div rows.  That is a known, documented limitation.
+static bool isX86EmulatedOnArm()
+{
+#if defined(_WIN32)
+  HMODULE k32 = GetModuleHandleW(L"kernel32.dll");
+  if (!k32) return false;
+  using IsWow64Process2Fn = BOOL(WINAPI *)(HANDLE, USHORT *, USHORT *);
+  auto fn = reinterpret_cast<IsWow64Process2Fn>(
+      GetProcAddress(k32, "IsWow64Process2"));
+  if (!fn) return false;
+  USHORT procMachine = 0, nativeMachine = 0;
+  if (!fn(GetCurrentProcess(), &procMachine, &nativeMachine)) return false;
+  const USHORT kAmd64 = 0x8664, kI386 = 0x014c, kArm64 = 0xaa64;
+  return (procMachine == kAmd64 || procMachine == kI386) &&
+         nativeMachine == kArm64;
+#elif defined(__APPLE__)
+  int translated = 0;
+  size_t s = sizeof(translated);
+  if (sysctlbyname("sysctl.proc_translated", &translated, &s, nullptr, 0) == 0)
+    return translated != 0;
+  return false;
+#elif defined(__linux__)
+  struct utsname u;
+  if (uname(&u) != 0) return false;
+  return std::strcmp(u.machine, "aarch64") == 0 ||
+         std::strncmp(u.machine, "arm", 3) == 0;
+#else
+  return false;
 #endif
 }
 #endif
@@ -229,6 +275,9 @@ static CpuFeatures detect()
   // the registry, "CP 4024"/"CP 4045", to match).
 #endif
 #endif // __aarch64__ || _M_ARM64
+#endif
+#if defined(CLPEAK_X86)
+  f.emulatedX86OnArm = isX86EmulatedOnArm();
 #endif
   return f;
 }
@@ -528,7 +577,12 @@ const CpuKernelMenu &kernelMenu()
     if (f.avx2 && f.fma)
     {
       addBase(clpeak_table_avx2(), "AVX2+FMA");
-      addDivSqrt(clpeak_table_avx2(), "AVX2");   // no FMA in a div/sqrt chain
+      // No FMA in a div/sqrt chain.  Suppressed when this x86 binary is
+      // translated on ARM64 (Prism/Rosetta/qemu-user): the 256-bit op is
+      // cracked to 2x128-bit NEON, so counting 2x lanes inflates the row past
+      // native (Snapdragon X: AVX2 fdiv read 1.4-1.6x NEON for the same unit).
+      if (!f.emulatedX86OnArm)
+        addDivSqrt(clpeak_table_avx2(), "AVX2");
       add(m.strscan, clpeak_table_avx2()->strscan, "AVX2");
       add(m.utf8, clpeak_table_avx2()->utf8, "AVX2");
     }
@@ -537,7 +591,9 @@ const CpuKernelMenu &kernelMenu()
     if (f.avx512f && f.avx512bw && f.avx512vl && f.avx512dq)
     {
       addBase(clpeak_table_avx512(), "AVX-512");
-      addDivSqrt(clpeak_table_avx512(), "AVX-512");
+      // Same emulation cap as AVX2 above (512-bit would inflate 4x).
+      if (!f.emulatedX86OnArm)
+        addDivSqrt(clpeak_table_avx512(), "AVX-512");
       add(m.strscan, clpeak_table_avx512()->strscan, "AVX-512");   // VPCMPB+KOR
       add(m.utf8, clpeak_table_avx512()->utf8, "AVX-512");         // 512-bit VPSHUFB
     }

--- a/src/cpu/cpu_kernels.h
+++ b/src/cpu/cpu_kernels.h
@@ -53,6 +53,11 @@ struct CpuFeatures {
   // AVX-512 OS grant, checked via avx512f at the menu push).
   bool aes = false, sha256 = false, sha512 = false, crc32 = false;
   bool vaes = false;
+  // x86 binary translated on an ARM64 host (Windows Prism, Apple Rosetta 2,
+  // Linux qemu-user).  Guest CPUID still reports AVX2/AVX-512, but the
+  // ops/lane scaling of div/sqrt does not match the emulated execution width,
+  // so kernelMenu() suppresses wider-than-128b div/sqrt rows.
+  bool emulatedX86OnArm = false;
 };
 
 const CpuFeatures &cpuFeatures();   // cached runtime probe

--- a/src/cpu/cpu_peak.cpp
+++ b/src/cpu/cpu_peak.cpp
@@ -138,6 +138,11 @@ int CpuPeak::runAll()
   std::vector<logger::Prop> props;
   props.push_back({"Vendor", info.vendor.empty() ? "Unknown" : info.vendor});
   props.push_back({"ISA",    info.isaName});
+  // An x86 binary translated on ARM64 (Prism/Rosetta/qemu-user) still reports
+  // guest CPUID widths, so name the translation: otherwise a suppressed AVX2
+  // divider row looks like a missing feature rather than a host-width cap.
+  if (info.emulatedX86OnArm)
+    props.push_back({"Emulation", "x64 on ARM64 (wider SIMD rows suppressed)"});
   {
     std::string cores = std::to_string(info.logicalCores) + " threads / " +
                         std::to_string(info.physicalCores) + " cores";

--- a/src/onnx/AGENTS.md
+++ b/src/onnx/AGENTS.md
@@ -1177,6 +1177,22 @@ than because it was convenient, and it is meant to stay fixed forever:
   of what the error means. Comparing accuracy across devices requires the same
   depth on each.
 
+## Rate and accuracy stay in step
+
+`onnx-gemm` and `onnx-numeric-error` are a pair over their overlapping labels
+(the plain-float dtypes plus int8_qdq; the weight-only and nvfp4 rows have no
+accuracy counterpart by design). They gate on the same fusion check and try
+the same signed→unsigned int8 schemes, so their supported sets stay symmetric.
+
+When `onnx-gemm`'s ladder proves the provider folded the resident operands at
+compile time, the rate row is refused as meaningless. `onnx-numeric-error` uses
+a non-resident graph that cannot fold, so it would still produce a number — but
+an accuracy without its rate is one half of a pair, and publishing it alone
+would look like a contradiction. It is therefore suppressed for the same label,
+with the reason noting that the paired gemm row folded. Other failure modes
+(session refused, no fused quantized matmul, dtype unsupported) remain
+independent: each test reports its own gate faithfully.
+
 ## Measuring the cable, and what it cost to try
 
 `onnx-transfer-bw` measures the thing every other test here is built to avoid:

--- a/src/onnx/block.cpp
+++ b/src/onnx/block.cpp
@@ -145,14 +145,14 @@ namespace
       {"int8_qdq", ONNX_DT_FLOAT16, ONNX_DT_INT8, 0, /*qdq=*/true,
        /*sweep=*/false, "ops",
        "8-bit weights and 8-bit arithmetic through the projections, quantized in "
-       "and quantized out -- the form an NPU's headline TOPS figure is quoted "
+       "and quantized out -- the form vendors usually quote headline TOPS figures "
        "for, now measured on a whole layer rather than one matmul.  Attention and "
        "the softmax stay 16-bit, as they do in every real deployment."},
 
       {"fp32", ONNX_DT_FLOAT, ONNX_DT_FLOAT, 0, false, /*sweep=*/false, nullptr,
        "Full precision, which nobody serves a language model in.  It is here as a "
        "control: a provider whose fp16 row fails to beat it is not running "
-       "half-precision hardware, and on some CPU providers this is the only row "
+       "half-precision hardware, and on some providers this is the only row "
        "with a native kernel behind it."},
 
       {"bf16", ONNX_DT_BFLOAT16, ONNX_DT_BFLOAT16, 0, false, /*sweep=*/false,

--- a/src/onnx/conv.cpp
+++ b/src/onnx/conv.cpp
@@ -86,7 +86,7 @@ namespace
   const Shape kShapes[] = {
       {3, false, "conv3x3",
        "A 3x3 convolution over 256 channels -- the shape most vision networks "
-       "are built from, and the one neural accelerators were designed "
+       "are built from, and the one accelerators were designed "
        "around."},
       {1, false, "conv1x1",
        "A 1x1 convolution: arithmetically a matrix multiply applied at every "
@@ -265,7 +265,7 @@ int OnnxPeak::runConv(const OrtRuntime &rt, const onnx_ep_info_t &ep,
   auto test = currentDeviceScope->beginTest(
       {"onnx_conv", "ONNX convolution peak", "flops", Category::Compute,
        "Convolution speed at the precision each row names, swept over "
-       "feature-map sizes and reported at its best.  Neural accelerators were "
+       "feature-map sizes and reported at its best.  Accelerators were "
        "built for this operation before they were asked to do anything else, "
        "and many reach a higher share of their arithmetic peak here than on a "
        "plain matrix multiply.  Read alongside the matmul rows: the gap "

--- a/src/onnx/dispatch_latency.cpp
+++ b/src/onnx/dispatch_latency.cpp
@@ -196,9 +196,10 @@ int OnnxPeak::runDispatchLatency(const OrtRuntime &rt, const onnx_ep_info_t &ep,
 
   if (trivial.createUs > 0.0)
     test.emit("session_create", (float)(trivial.createUs * 1e-6),
-              "Preparing that trivial graph for execution.  On NPU providers "
-              "this runs a compiler rather than bookkeeping, which is why "
-              "starting up and running steadily are such different stories.");
+              "Preparing that trivial graph for execution.  On providers that "
+              "compile graphs ahead of time this runs a compiler rather than "
+              "bookkeeping, which is why starting up and running steadily are "
+              "such different stories.");
   else
     test.skip("session_create", trivial.status, trivial.error,
               "Preparing the trivial graph for execution.");

--- a/src/onnx/gemm.cpp
+++ b/src/onnx/gemm.cpp
@@ -455,10 +455,11 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
       {ONNX_DT_FLOAT, false, "fp32",
        "FP32 graph inputs and outputs.  A provider may use a narrower internal "
        "format; read the fp32 numeric-error row beside this one to see whether "
-       "it did.  Many NPUs cannot run this at all, or route it away from the "
-       "matrix hardware -- that is a finding, not a failure."},
+       "it did.  Many providers cannot run this on their matrix hardware at "
+       "all, or route it away from that hardware -- that is a finding, not "
+       "a failure."},
       {ONNX_DT_FLOAT16, false, "fp16",
-       "16-bit floats, the native currency of most NPU matrix hardware."},
+       "16-bit floats, the native currency of most matrix hardware."},
       {ONNX_DT_BFLOAT16, false, "bf16",
        "The 16-bit float with fp32's exponent range and three fewer mantissa "
        "bits.  Modern matrix hardware usually runs it at the fp16 rate; a "
@@ -508,8 +509,8 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
   static const Variant kIntVariants[] = {
       {ONNX_DT_INT8, true, "int8_qdq",
        "8-bit integers in QDQ form -- quantized in, quantized out, the shape "
-       "quantized inference actually ships in.  This is what an NPU's headline "
-       "TOPS figure is quoted for."},
+       "quantized inference actually ships in.  This is what vendors usually "
+       "quote headline TOPS figures for."},
   };
 
   auto test = currentDeviceScope->beginTest(
@@ -518,8 +519,8 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
        Category::Unknown,
        "Matrix-multiply speed through ONNX Runtime on this execution "
        "provider, using a single-operation model with constant weights.  "
-       "The identical model runs on every provider, so NPU, GPU and CPU "
-       "rows are directly comparable -- and the gap against a vendor's "
+       "The identical model runs on every provider, so rows from different "
+       "providers are directly comparable -- and the gap against a vendor's "
        "advertised TOPS is real, not an artifact of different test code.  "
        "Providers that cannot run an operation entirely on their device "
        "report it as unsupported instead of quietly measuring the CPU.  "

--- a/src/onnx/gemm.cpp
+++ b/src/onnx/gemm.cpp
@@ -526,6 +526,11 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
        "Each reading is a different input format.",
        TestShape::Heterogeneous, "data type"});
 
+  // runAll also clears per EP before dispatching; this entry clear keeps
+  // direct runGemm callers (tests, future entry points) from inheriting a
+  // stale record from an earlier run in the same process.
+  onnxClearGemmFolded(ep);
+
   // ---- Sweep every variant (all data types in one test) ---------------
   // Helper to run one variant's sweep
   auto runVariant = [&](const Variant &v) {
@@ -545,6 +550,9 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
     int64_t bestDim = 0;
     std::string firstErr;
     ResultStatus errStatus = ResultStatus::Unsupported;
+    // Set by either folding guard below; drives the paired suppression in
+    // runNumericError (see onnx_probe.h).
+    bool folded = false;
 
     // First and last timings with their sizes, to confirm the work actually
     // happened (see the folding check after the loop).
@@ -788,6 +796,7 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
                    "the timings do not scale with the problem size and mean "
                    "nothing";
         errStatus = ResultStatus::Error;
+        folded = true;
         break;
       }
       prevRate = rate;
@@ -897,6 +906,7 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
                  "which ONNX Runtime did before about 1.18, so the timings "
                  "do not scale with the problem size and mean nothing";
       errStatus = ResultStatus::Error;
+      folded = true;
     }
 
     logger::EmitOptions o;
@@ -929,6 +939,8 @@ int OnnxPeak::runGemm(const OrtRuntime &rt, const onnx_ep_info_t &ep,
       o.description = std::string("Peak over a doubling sweep of square sizes.  ") + v.note;
       if (isInt)
         o.unit = "ops";
+      if (folded)
+        onnxNoteGemmFolded(ep, v.label);
       test.skip(v.label, errStatus,
                 firstErr.empty() ? "no supported datatype" : firstErr, o);
     }

--- a/src/onnx/numeric_error.cpp
+++ b/src/onnx/numeric_error.cpp
@@ -13,7 +13,10 @@
 // quantization scheme's rather than the integer unit's -- the same distinction
 // onnx_gemm refuses to publish a rate without.  Both tests now gate on the
 // same fusion check and try the same signed→unsigned schemes, so their
-// supported sets stay symmetric.
+// supported sets stay symmetric.  They also stay in step on folding: when
+// gemm's resident ladder proves the provider folded the operands, the rate is
+// refused and this row is suppressed with it (see onnxGemmFolded), even
+// though this test's non-resident graph would still run.
 //
 // The fp32 row does a second job.  clpeak's CPU-fallback guard works at
 // ORT's partitioning level, so it cannot see an EP that accepts a node and
@@ -328,6 +331,23 @@ int OnnxPeak::runNumericError(const OrtRuntime &rt, const onnx_ep_info_t &ep,
     if (std::string why = onnxDtypeUnsupportedReason(rt, v.dtype); !why.empty())
     {
       test.skip(v.label, ResultStatus::Unsupported, why, o.description);
+      continue;
+    }
+
+    // Paired suppression: gemm's ladder proved this provider folded the
+    // resident operands for this label, so its rate was refused as
+    // meaningless.  This test's non-resident graph cannot fold and would
+    // still produce a number -- but a rate without its accuracy is half a
+    // number, and so is an accuracy without its rate.  Suppress rather than
+    // publish one half of the pair alone.
+    if (onnxGemmFolded(ep, v.label))
+    {
+      CLPEAK_VLOG("onnx-numeric-error[%s/%s]: suppressed (gemm folded)\n",
+                  ep.providerKey.c_str(), v.label);
+      test.skip(v.label, ResultStatus::Unsupported,
+                "suppressed: onnx-gemm folded the operands for this datatype, "
+                "so no rate was published for the pair",
+                o.description);
       continue;
     }
 

--- a/src/onnx/onnx_peak.cpp
+++ b/src/onnx/onnx_peak.cpp
@@ -294,6 +294,12 @@ int OnnxPeak::runAll()
     {
       (void)onnxProbeGemmCache(*rt, ep);
     }
+    // Fresh folding record for this EP even when gemm itself is filtered
+    // out: otherwise a stale entry from an earlier run in the same process
+    // would suppress numeric-error rows that have no paired rate to stay in
+    // step with.  runGemm clears again and repopulates when it runs.
+    if (isAllowed(Benchmark::OnnxGemm) || isAllowed(Benchmark::OnnxNumericError))
+      onnxClearGemmFolded(ep);
 
     // ---- Compute (FLOPS + OPS) ---------------------------
     if (isAllowed(Benchmark::OnnxGemm))

--- a/src/onnx/onnx_probe.cpp
+++ b/src/onnx/onnx_probe.cpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <cmath>
 
@@ -497,6 +498,48 @@ const OnnxProbeCache &onnxProbeGemmCache(const OrtRuntime &rt, const onnx_ep_inf
   auto cache = onnxProbeGemmVariants(rt, ep);
   auto res = memo.emplace(memoKey, std::move(cache));
   return res.first->second;
+}
+
+namespace
+{
+std::string foldKey(const onnx_ep_info_t &ep)
+{
+  return ep.providerKey + '\x1f' + ep.epDevice;
+}
+struct FoldStore
+{
+  std::mutex mtx;
+  std::unordered_map<std::string, std::unordered_set<std::string>> map;
+};
+FoldStore &foldStore()
+{
+  static FoldStore s;
+  return s;
+}
+} // namespace
+
+void onnxNoteGemmFolded(const onnx_ep_info_t &ep, const std::string &label)
+{
+  FoldStore &s = foldStore();
+  std::lock_guard<std::mutex> lk(s.mtx);
+  s.map[foldKey(ep)].insert(label);
+}
+
+bool onnxGemmFolded(const onnx_ep_info_t &ep, const std::string &label)
+{
+  FoldStore &s = foldStore();
+  std::lock_guard<std::mutex> lk(s.mtx);
+  auto it = s.map.find(foldKey(ep));
+  if (it == s.map.end())
+    return false;
+  return it->second.count(label) > 0;
+}
+
+void onnxClearGemmFolded(const onnx_ep_info_t &ep)
+{
+  FoldStore &s = foldStore();
+  std::lock_guard<std::mutex> lk(s.mtx);
+  s.map.erase(foldKey(ep));
 }
 
 bool onnxEpViable(const OrtRuntime &rt, const onnx_ep_info_t &ep,

--- a/src/onnx/onnx_probe.h
+++ b/src/onnx/onnx_probe.h
@@ -57,5 +57,21 @@ OnnxProbeCache onnxProbeGemmVariants(const OrtRuntime &rt,
 bool onnxEpViable(const OrtRuntime &rt, const onnx_ep_info_t &ep,
                   std::string &reason);
 
+// onnx-gemm and onnx-numeric-error are a rate/accuracy pair over their
+// overlapping labels (the plain-float dtypes plus int8_qdq; the weight-only
+// and nvfp4 rows have no accuracy counterpart by design).  When gemm's ladder
+// proves the provider folded the resident operands at compile time, its rate
+// is suppressed as an error -- and the accuracy row for the same label is
+// suppressed with it, even though its non-resident graph did run.  That graph
+// cannot fold (its activations are a runtime input), so without this its
+// number would stand alone beside a rate that was refused as meaningless.
+// runGemm records each folded label here; runNumericError consults it.
+// Keyed by EP exactly like the probe cache above.  Cleared per EP in runAll
+// (and again at runGemm entry for direct callers) so a stale run cannot
+// suppress a later one.
+void onnxNoteGemmFolded(const onnx_ep_info_t &ep, const std::string &label);
+bool onnxGemmFolded(const onnx_ep_info_t &ep, const std::string &label);
+void onnxClearGemmFolded(const onnx_ep_info_t &ep);
+
 #endif // ENABLE_ONNX
 #endif // CLPEAK_ONNX_PROBE_H

--- a/src/onnx/tensor_bandwidth.cpp
+++ b/src/onnx/tensor_bandwidth.cpp
@@ -71,7 +71,7 @@ const Size kSizes[] = {
    "Eight megabytes of weights -- small enough to sit in fast local memory on "
    "most devices, so this is usually the fastest rung."},
   {4096, "32mb",
-   "Thirty-two megabytes -- around the size of a large cache or an NPU's local memory."},
+   "Thirty-two megabytes -- around the size of a large cache or a device's fast local memory."},
   {8192, "128mb",
    "128 megabytes -- past the cache of most devices, though not all."},
   {16384, "512mb",


### PR DESCRIPTION
- CPU: don't report inflated AVX2 / AVX-512 divide/sqrt rows when an x64 binary is translated on ARM64.
- ONNX: keep `onnx-gemm` rate and `onnx-numeric-error` accuracy in step when the provider folds constants.
- ONNX: neutral device wording in test descriptions (no NPU-specific language).